### PR TITLE
DM-50905 Update the nightly digest frontend to fetch data using data source adapters

### DIFF
--- a/doc/news/DM-50905.feature.md
+++ b/doc/news/DM-50905.feature.md
@@ -1,0 +1,7 @@
+### This PR does the following:
+- Update the nightly digest frontend to fetch data using the data source adapters; Almanac, ConsDB and Narrative Log.
+- Currently the following metrics cards on top of the page retrieve data from the data source adapters:
+    - The exposures metrics card (expected no of exposures is still TBD)
+    - Telescope Efficiency metrics card
+    - Time Loss metrics card; it should show numbers other than zero if time lost data is available in the narrative log
+- The no of tickets in Jira metrics card is TBD. It should be updated when the Jira adapter is created; see [DM-50983](https://rubinobs.atlassian.net/browse/DM-50983)

--- a/src/components/parameters.jsx
+++ b/src/components/parameters.jsx
@@ -9,16 +9,17 @@ import {
 import { Label } from "@/components/ui/label";
 import { DatePicker } from "@/components/ui/datepicker.jsx";
 
-const instruments = [
-  {
-    value: "simonyi",
-    label: "Simonyi",
-  },
-  {
-    value: "auxtel",
-    label: "AuxTel",
-  },
-];
+const TELESCOPES = Object.freeze({
+  AuxTel: "LATISS",
+  Simonyi: "LSSTCam",
+});
+
+const instruments = Object.keys(TELESCOPES).map((key) => {
+  return {
+    value: TELESCOPES[key],
+    label: key,
+  };
+});
 
 function Parameters({
   startDay,

--- a/src/components/ui/combobox.jsx
+++ b/src/components/ui/combobox.jsx
@@ -17,7 +17,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 
-export function ComboBox({ options, selectedValue }) {
+export function ComboBox({ options, selectedValue, handleChange }) {
   const [open, setOpen] = React.useState(false);
   const [value, setValue] = React.useState(selectedValue);
 
@@ -49,6 +49,7 @@ export function ComboBox({ options, selectedValue }) {
                   onSelect={(currentValue) => {
                     setValue(currentValue === value ? "" : currentValue);
                     setOpen(false);
+                    handleChange(currentValue);
                   }}
                 >
                   {option.label}

--- a/src/components/ui/datepicker.jsx
+++ b/src/components/ui/datepicker.jsx
@@ -17,7 +17,6 @@ export function DatePicker({ selectedDate, onDateChange }) {
 
   const handleChange = (newDate) => {
     setDate(newDate);
-    console.log("Date changed:", newDate);
     if (date) {
       onDateChange(date);
     }

--- a/src/components/ui/datepicker.jsx
+++ b/src/components/ui/datepicker.jsx
@@ -12,8 +12,16 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 
-export function DatePicker({ selectedDate }) {
+export function DatePicker({ selectedDate, onDateChange }) {
   const [date, setDate] = React.useState(selectedDate);
+
+  const handleChange = (newDate) => {
+    setDate(newDate);
+    console.log("Date changed:", newDate);
+    if (date) {
+      onDateChange(date);
+    }
+  };
 
   return (
     <Popover>
@@ -36,7 +44,7 @@ export function DatePicker({ selectedDate }) {
         <Calendar
           mode="single"
           selected={date}
-          onSelect={setDate}
+          onSelect={handleChange}
           initialFocus
         />
       </PopoverContent>

--- a/src/pages/layout.jsx
+++ b/src/pages/layout.jsx
@@ -12,15 +12,27 @@ import JiraIcon from "../assets/JiraIcon.svg";
 
 export default function Layout({ children }) {
   const [tickets, setTickets] = useState([]);
-  const [exposures, setExposures] = useState([]);
-  const [dayObsStart, setDayObsStart] = useState(new Date());
-  const [dayObsEnd, setDayObsEnd] = useState(new Date());
-  const [instrument, setInstrument] = useState("auxtel");
+  const [exposures, setExposures] = useState(0);
+  const [dayObsStart, setDayObsStart] = useState(new Date(2025, 2, 1));
+  const [dayObsEnd, setDayObsEnd] = useState(new Date(2025, 2, 2));
+  const [instrument, setInstrument] = useState("LSSTCam");
+
+  const handleStartDateChange = (date) => {
+    console.log("Start date changed:", date);
+    setDayObsStart(date);
+  };
+
+  const handleInstrumentChange = (inst) => {
+    console.log("Instrument changed:", inst);
+    setInstrument(inst);
+  };
 
   useEffect(() => {
+    console.log("Effect triggered", dayObsStart, dayObsEnd, instrument);
+    let start = dayObsStart.toISOString().split("T")[0];
+    let end = dayObsEnd.toISOString().split("T")[0];
+
     async function fetchJiraTickets() {
-      let start = dayObsStart.toISOString().split("T")[0];
-      let end = dayObsEnd.toISOString().split("T")[0];
       const res = await fetch(
         `http://0.0.0.0:8000/jira-tickets?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
         {
@@ -39,8 +51,6 @@ export default function Layout({ children }) {
     }
 
     async function fetchExposures() {
-      let start = dayObsStart.toISOString().split("T")[0];
-      let end = dayObsEnd.toISOString().split("T")[0];
       const res = await fetch(
         `http://0.0.0.0:8000/exposures?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
         {
@@ -52,7 +62,7 @@ export default function Layout({ children }) {
       );
       if (res.ok) {
         const data = JSON.parse(await res.text());
-        setExposures(data.exposures);
+        setExposures(data.exposures_count);
       } else {
         console.log("error");
       }
@@ -67,11 +77,11 @@ export default function Layout({ children }) {
       <SidebarProvider>
         <AppSidebar
           startDay={dayObsStart}
-          onStartDayChange={setDayObsStart}
+          onStartDayChange={handleStartDateChange}
           endDay={dayObsEnd}
           onEndDayChange={setDayObsEnd}
           instrument={instrument}
-          onInstrumentChange={setInstrument}
+          onInstrumentChange={handleInstrumentChange}
         />
         <main className="w-full bg-stone-800">
           {/* Show/Hide Sidebar button */}

--- a/src/pages/layout.jsx
+++ b/src/pages/layout.jsx
@@ -22,6 +22,16 @@ export default function Layout({ children }) {
   const [timeLossDetails, setTimeLossDetails] = useState(
     "(- weather; - fault)",
   );
+  const [nightHours, setNightHours] = useState(0.0);
+  const [weatherLoss, setWeatherLoss] = useState(0.0);
+  const [sumExpTime, setSumExpTime] = useState(0.0);
+  const [faultLoss, setFaultLoss] = useState(0.0);
+
+  // const httpProtocol = window.location.protocol;
+  // const host = window.location.host;
+  // const backendLocation = `${httpProtocol}//${host}/nightlydigest/api`;
+  //TODO: use the above code to get the backend location dynamically
+  const backendLocation = "http://0.0.0.0:8000";
 
   const handleStartDateChange = (date) => {
     setDayObsStart(date);
@@ -32,17 +42,8 @@ export default function Layout({ children }) {
   };
 
   useEffect(() => {
-    console.log("Effect triggered", dayObsStart, dayObsEnd, instrument);
     let start = dayObsStart.toISOString().split("T")[0];
     let end = dayObsEnd.toISOString().split("T")[0];
-    let sumExpTime = 0.0;
-    let nightHours = 0.0;
-    let weatherLoss = 0.0;
-    let faultLoss = 0.0;
-
-    const httpProtocol = window.location.protocol;
-    const host = window.location.host;
-    const backendLocation = `${httpProtocol}//${host}/nightlydigest/api`;
 
     async function fetchExposures() {
       const res = await fetch(
@@ -57,8 +58,7 @@ export default function Layout({ children }) {
       if (res.ok) {
         const data = JSON.parse(await res.text());
         setExposures(data.exposures_count);
-        sumExpTime = data.sum_exposure_time;
-        console.log(sumExpTime);
+        setSumExpTime(data.sum_exposure_time);
       } else {
         console.log("error");
       }
@@ -76,7 +76,7 @@ export default function Layout({ children }) {
       );
       if (res.ok) {
         const data = JSON.parse(await res.text());
-        nightHours = data.night_hours;
+        setNightHours(data.night_hours);
       } else {
         console.log("error");
       }
@@ -94,8 +94,8 @@ export default function Layout({ children }) {
       );
       if (res.ok) {
         const data = JSON.parse(await res.text());
-        weatherLoss = data.time_lost_to_weather;
-        faultLoss = data.time_lost_to_faults;
+        setWeatherLoss(data.time_lost_to_weather);
+        setFaultLoss(faultLoss);
       } else {
         console.log("error");
       }
@@ -105,7 +105,9 @@ export default function Layout({ children }) {
     fetchExposures();
     fetchAlmanac();
     fetchNarrativeLog();
+  }, [dayObsStart, dayObsEnd, instrument]);
 
+  useEffect(() => {
     // Calculate efficiency
     let eff = calculateEfficiency(nightHours, sumExpTime, weatherLoss);
     setEfficiency(eff);
@@ -124,7 +126,7 @@ export default function Layout({ children }) {
       setTimeLoss("0 hours");
       setTimeLossDetails("(- weather; - fault)");
     }
-  }, [dayObsStart, dayObsEnd, instrument]);
+  }, [sumExpTime, weatherLoss, nightHours, faultLoss]);
 
   return (
     <>

--- a/src/pages/layout.jsx
+++ b/src/pages/layout.jsx
@@ -40,9 +40,13 @@ export default function Layout({ children }) {
     let weatherLoss = 0.0;
     let faultLoss = 0.0;
 
+    const httpProtocol = window.location.protocol;
+    const host = window.location.host;
+    const backendLocation = `${httpProtocol}//${host}/nightlydigest/api`;
+
     async function fetchExposures() {
       const res = await fetch(
-        `http://0.0.0.0:8000/exposures?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
+        `${backendLocation}/exposures?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
         {
           method: "GET",
           headers: {
@@ -62,7 +66,7 @@ export default function Layout({ children }) {
 
     async function fetchAlmanac() {
       const res = await fetch(
-        `http://0.0.0.0:8000/almanac?dayObsStart=${start}&dayObsEnd=${end}`,
+        `${backendLocation}/almanac?dayObsStart=${start}&dayObsEnd=${end}`,
         {
           method: "GET",
           headers: {
@@ -80,7 +84,7 @@ export default function Layout({ children }) {
 
     async function fetchNarrativeLog() {
       const res = await fetch(
-        `http://0.0.0.0:8000/narrative-log?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
+        `${backendLocation}/narrative-log?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
         {
           method: "GET",
           headers: {

--- a/src/pages/layout.jsx
+++ b/src/pages/layout.jsx
@@ -27,11 +27,9 @@ export default function Layout({ children }) {
   const [sumExpTime, setSumExpTime] = useState(0.0);
   const [faultLoss, setFaultLoss] = useState(0.0);
 
-  // const httpProtocol = window.location.protocol;
-  // const host = window.location.host;
-  // const backendLocation = `${httpProtocol}//${host}/nightlydigest/api`;
-  //TODO: use the above code to get the backend location dynamically
-  const backendLocation = "http://0.0.0.0:8000";
+  const httpProtocol = window.location.protocol;
+  const host = window.location.host;
+  const backendLocation = `${httpProtocol}//${host}/nightlydigest/api`;
 
   const handleStartDateChange = (date) => {
     setDayObsStart(date);

--- a/src/pages/layout.jsx
+++ b/src/pages/layout.jsx
@@ -11,7 +11,6 @@ import TimeLossIcon from "../assets/TimeLossIcon.svg";
 import JiraIcon from "../assets/JiraIcon.svg";
 
 export default function Layout({ children }) {
-  const [tickets, setTickets] = useState([]);
   const [exposures, setExposures] = useState(0);
   const [dayObsStart, setDayObsStart] = useState(new Date(2025, 4, 12));
   const [dayObsEnd, setDayObsEnd] = useState(new Date(2025, 4, 13));
@@ -37,24 +36,6 @@ export default function Layout({ children }) {
     let nightHours = 0.0;
     let weatherLoss = 0.0;
     let faultLoss = 0.0;
-
-    async function fetchJiraTickets() {
-      const res = await fetch(
-        `http://0.0.0.0:8000/jira-tickets?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        },
-      );
-      if (res.ok) {
-        const tix = JSON.parse(await res.text());
-        setTickets(tix.issues);
-      } else {
-        console.log("error");
-      }
-    }
 
     async function fetchExposures() {
       const res = await fetch(
@@ -113,7 +94,6 @@ export default function Layout({ children }) {
       }
     }
 
-    fetchJiraTickets();
     fetchExposures();
     fetchAlmanac();
     fetchNarrativeLog();

--- a/src/pages/layout.jsx
+++ b/src/pages/layout.jsx
@@ -11,7 +11,8 @@ import TimeLossIcon from "../assets/TimeLossIcon.svg";
 import JiraIcon from "../assets/JiraIcon.svg";
 
 export default function Layout({ children }) {
-  const [nooftickets, setNooftickets] = useState(0);
+  const [tickets, setTickets] = useState([]);
+  const [exposures, setExposures] = useState([]);
   const [dayObsStart, setDayObsStart] = useState(new Date());
   const [dayObsEnd, setDayObsEnd] = useState(new Date());
   const [instrument, setInstrument] = useState("auxtel");
@@ -31,13 +32,34 @@ export default function Layout({ children }) {
       );
       if (res.ok) {
         const tix = JSON.parse(await res.text());
-        setNooftickets(tix.issues.length);
+        setTickets(tix.issues);
+      } else {
+        console.log("error");
+      }
+    }
+
+    async function fetchExposures() {
+      let start = dayObsStart.toISOString().split("T")[0];
+      let end = dayObsEnd.toISOString().split("T")[0];
+      const res = await fetch(
+        `http://0.0.0.0:8000/exposures?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+      if (res.ok) {
+        const data = JSON.parse(await res.text());
+        setExposures(data.exposures);
       } else {
         console.log("error");
       }
     }
 
     fetchJiraTickets();
+    fetchExposures();
   }, [dayObsStart, dayObsEnd, instrument]);
 
   return (

--- a/src/pages/layout.jsx
+++ b/src/pages/layout.jsx
@@ -9,7 +9,7 @@ import ShutterIcon from "../assets/ShutterIcon.svg";
 import EfficiencyIcon from "../assets/EfficiencyIcon.svg";
 import TimeLossIcon from "../assets/TimeLossIcon.svg";
 import JiraIcon from "../assets/JiraIcon.svg";
-import { calculateEfficiency } from "@/utils/fetchUtils";
+import { calculateEfficiency, calculateTimeLoss } from "@/utils/fetchUtils";
 
 export default function Layout({ children }) {
   const [exposures, setExposures] = useState(0);
@@ -114,18 +114,9 @@ export default function Layout({ children }) {
     setEfficiencyText(`${eff} %`);
 
     // Calculate time loss
-    let loss = weatherLoss + faultLoss;
-    if (loss > 0) {
-      let weatherPercent = (weatherLoss / loss) * 100;
-      let faultPercent = (faultLoss / loss) * 100;
-      setTimeLoss(`${loss} hours`);
-      setTimeLossDetails(
-        `(${weatherPercent}% weather; ${faultPercent}% fault)`,
-      );
-    } else {
-      setTimeLoss("0 hours");
-      setTimeLossDetails("(- weather; - fault)");
-    }
+    let lossValues = calculateTimeLoss(weatherLoss, faultLoss);
+    setTimeLoss(lossValues[0]);
+    setTimeLossDetails(lossValues[1]);
   }, [sumExpTime, weatherLoss, nightHours, faultLoss]);
 
   return (

--- a/src/pages/layout.jsx
+++ b/src/pages/layout.jsx
@@ -46,58 +46,74 @@ export default function Layout({ children }) {
     let end = dayObsEnd.toISOString().split("T")[0];
 
     async function fetchExposures() {
-      const res = await fetch(
-        `${backendLocation}/exposures?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
+      try {
+        const res = await fetch(
+          `${backendLocation}/exposures?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
           },
-        },
-      );
-      if (res.ok) {
-        const data = JSON.parse(await res.text());
+        );
+        if (!res.ok) {
+          const errorText = await res.text();
+          console.error(`Fetch failed with status ${res.status}: ${errorText}`);
+          return;
+        }
+        const data = await res.json();
         setExposures(data.exposures_count);
         setSumExpTime(data.sum_exposure_time);
-      } else {
-        console.log("error");
+      } catch (error) {
+        console.error("Error fetching exposures:", error);
       }
     }
 
     async function fetchAlmanac() {
-      const res = await fetch(
-        `${backendLocation}/almanac?dayObsStart=${start}&dayObsEnd=${end}`,
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
+      try {
+        const res = await fetch(
+          `${backendLocation}/almanac?dayObsStart=${start}&dayObsEnd=${end}`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
           },
-        },
-      );
-      if (res.ok) {
-        const data = JSON.parse(await res.text());
+        );
+        if (!res.ok) {
+          const errorText = await res.text();
+          console.error(`Fetch failed with status ${res.status}: ${errorText}`);
+          return;
+        }
+
+        const data = await res.json();
         setNightHours(data.night_hours);
-      } else {
-        console.log("error");
+      } catch (error) {
+        console.error("Error fetching almanac:", error);
       }
     }
 
     async function fetchNarrativeLog() {
-      const res = await fetch(
-        `${backendLocation}/narrative-log?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
+      try {
+        const res = await fetch(
+          `${backendLocation}/narrative-log?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
           },
-        },
-      );
-      if (res.ok) {
-        const data = JSON.parse(await res.text());
+        );
+        if (!res.ok) {
+          const errorText = await res.text();
+          console.error(`Fetch failed with status ${res.status}: ${errorText}`);
+          return;
+        }
+        const data = await res.json();
         setWeatherLoss(data.time_lost_to_weather);
         setFaultLoss(faultLoss);
-      } else {
-        console.log("error");
+      } catch (error) {
+        console.error("Error fetching narrative log:", error);
       }
     }
 

--- a/src/pages/layout.jsx
+++ b/src/pages/layout.jsx
@@ -16,12 +16,7 @@ export default function Layout({ children }) {
   const [dayObsStart, setDayObsStart] = useState(new Date(2025, 4, 12));
   const [dayObsEnd, setDayObsEnd] = useState(new Date(2025, 4, 13));
   const [instrument, setInstrument] = useState("LSSTCam");
-  const [efficiency, setEfficiency] = useState(0);
-  const [efficiencyText, setEfficiencyText] = useState(`${efficiency} %`);
-  const [timeLoss, setTimeLoss] = useState("0 hours");
-  const [timeLossDetails, setTimeLossDetails] = useState(
-    "(- weather; - fault)",
-  );
+
   const [nightHours, setNightHours] = useState(0.0);
   const [weatherLoss, setWeatherLoss] = useState(0.0);
   const [sumExpTime, setSumExpTime] = useState(0.0);
@@ -121,17 +116,9 @@ export default function Layout({ children }) {
     fetchNarrativeLog();
   }, [dayObsStart, dayObsEnd, instrument]);
 
-  useEffect(() => {
-    // Calculate efficiency
-    let eff = calculateEfficiency(nightHours, sumExpTime, weatherLoss);
-    setEfficiency(eff);
-    setEfficiencyText(`${eff} %`);
-
-    // Calculate time loss
-    let lossValues = calculateTimeLoss(weatherLoss, faultLoss);
-    setTimeLoss(lossValues[0]);
-    setTimeLossDetails(lossValues[1]);
-  }, [sumExpTime, weatherLoss, nightHours, faultLoss]);
+  const efficiency = calculateEfficiency(nightHours, sumExpTime, weatherLoss);
+  const efficiencyText = `${efficiency} %`;
+  const [timeLoss, timeLossDetails] = calculateTimeLoss(weatherLoss, faultLoss);
 
   return (
     <>

--- a/src/utils/fetchUtils.jsx
+++ b/src/utils/fetchUtils.jsx
@@ -11,7 +11,7 @@ const calculateEfficiency = (nightHours, sumExpTime, weatherLoss) => {
   if (nightHours !== 0) {
     eff = sumExpTime / (nightHours * 60 * 60 - weatherLoss);
   }
-  return eff;
+  return eff === 0 ? 0 : eff.toFixed(2);
 };
 
 export { calculateEfficiency };

--- a/src/utils/fetchUtils.jsx
+++ b/src/utils/fetchUtils.jsx
@@ -39,4 +39,119 @@ const calculateTimeLoss = (weatherLoss, faultLoss) => {
 
   return [timeLoss, timeLossDetails];
 };
-export { calculateEfficiency, calculateTimeLoss };
+
+const httpProtocol = window.location.protocol;
+const host = window.location.host;
+/**
+ * The base URL for the backend API endpoints.
+ *
+ * Combines the HTTP protocol and host to form the full API root path.
+ * Example: "https://example.com/nightlydigest/api"
+ *
+ * @type {string}
+ */
+const backendLocation = `${httpProtocol}//${host}/nightlydigest/api`;
+
+/**
+ * Asynchronously fetches JSON data from the specified URL using a GET request.
+ *
+ * @async
+ * @function fetchData
+ * @param {string} url - The endpoint URL to fetch data from.
+ * @returns {Promise<Object|undefined>} The parsed JSON data if the request is successful, otherwise undefined.
+ * @throws Will log an error to the console if the fetch fails or the response is not OK.
+ */
+const fetchData = async (url) => {
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error(
+        `Fetch ${url} failed with status ${res.status}: ${errorText}`,
+      );
+      return;
+    }
+    const data = await res.json();
+    return data;
+  } catch (error) {
+    console.error(`Error fetching data from ${url}`, error);
+  }
+};
+
+/**
+ * Fetches the count of exposures and total exposure time for a given instrument within a date range.
+ *
+ * @async
+ * @function fetchExposures
+ * @param {string} start - The start date for the observation range (format: YYYY-MM-DD).
+ * @param {string} end - The end date for the observation range (format: YYYY-MM-DD).
+ * @param {string} instrument - The name of the instrument to filter exposures.
+ * @returns {Promise<[number, number]>} A promise that resolves to an array containing:
+ *   [0]: exposures_count (number) - The number of exposures.
+ *   [1]: sum_exposure_time (number) - The total exposure time.
+ */
+const fetchExposures = async (start, end, instrument) => {
+  const url = `${backendLocation}/exposures?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`;
+  const data = await fetchData(url);
+  if (!data) {
+    console.error("Error fetching exposures");
+    return [0, 0];
+  }
+
+  return [data.exposures_count, data.sum_exposure_time];
+};
+
+/**
+ * Fetches the number of night hours from the Almanac API for a given date range.
+ *
+ * @async
+ * @function fetchAlmanac
+ * @param {string} start - The start date of the observation period (in YYYY-MM-DD format).
+ * @param {string} end - The end date of the observation period (in YYYY-MM-DD format).
+ * @returns {Promise<number>} The number of night hours for the specified range, or 0.0 if an error occurs.
+ */
+const fetchAlmanac = async (start, end) => {
+  const url = `${backendLocation}/almanac?dayObsStart=${start}&dayObsEnd=${end}`;
+  const data = await fetchData(url);
+
+  if (!data) {
+    console.error("Error fetching Almanac");
+    return 0.0;
+  }
+  return data.night_hours;
+};
+
+/**
+ * Fetches the narrative log data for a given date range and instrument.
+ *
+ * @async
+ * @function fetchNarrativeLog
+ * @param {string} start - The start date of the observation range (format: YYYY-MM-DD).
+ * @param {string} end - The end date of the observation range (format: YYYY-MM-DD).
+ * @param {string} instrument - The instrument identifier to filter the narrative log.
+ * @returns {Promise<[number, number]>} A promise that resolves to an array containing:
+ *   [time_lost_to_weather, time_lost_to_faults]. Returns [0, 0] if fetching fails.
+ */
+const fetchNarrativeLog = async (start, end, instrument) => {
+  const url = `${backendLocation}/narrative-log?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`;
+  const data = await fetchData(url);
+
+  if (!data) {
+    console.error("Error fetching Narrative Log");
+    return [0, 0];
+  }
+  return [data.time_lost_to_weather, data.time_lost_to_faults];
+};
+
+export {
+  calculateEfficiency,
+  calculateTimeLoss,
+  fetchExposures,
+  fetchAlmanac,
+  fetchNarrativeLog,
+};

--- a/src/utils/fetchUtils.jsx
+++ b/src/utils/fetchUtils.jsx
@@ -23,6 +23,8 @@ const calculateEfficiency = (nightHours, sumExpTime, weatherLoss) => {
  * and the second element is a string detailing the percentage breakdown of weather and fault losses.
  */
 const calculateTimeLoss = (weatherLoss, faultLoss) => {
+  weatherLoss = weatherLoss / 3600; // Convert seconds to hours
+  faultLoss = faultLoss / 3600; // Convert seconds to hours
   let loss = weatherLoss + faultLoss;
 
   let timeLoss = "0 hours";
@@ -35,6 +37,6 @@ const calculateTimeLoss = (weatherLoss, faultLoss) => {
     timeLossDetails = `(${weatherPercent}% weather; ${faultPercent}% fault)`;
   }
 
-  return timeLoss, timeLossDetails;
+  return [timeLoss, timeLossDetails];
 };
 export { calculateEfficiency, calculateTimeLoss };

--- a/src/utils/fetchUtils.jsx
+++ b/src/utils/fetchUtils.jsx
@@ -1,0 +1,9 @@
+const calculateEfficiency = (nightHours, sumExpTime, weatherLoss) => {
+  let eff = 0.0;
+  if (nightHours !== 0) {
+    eff = sumExpTime / (nightHours * 60 * 60 - weatherLoss);
+  }
+  return eff;
+};
+
+export { calculateEfficiency };

--- a/src/utils/fetchUtils.jsx
+++ b/src/utils/fetchUtils.jsx
@@ -1,3 +1,11 @@
+/**
+ * Calculates the efficiency of night hours usage, accounting for exposure time and weather loss.
+ *
+ * @param {number} nightHours - The total number of night hours available.
+ * @param {number} sumExpTime - The sum of exposure time in seconds.
+ * @param {number} weatherLoss - The total time lost due to weather in seconds.
+ * @returns {number} The calculated efficiency as a ratio (0 if nightHours is 0).
+ */
 const calculateEfficiency = (nightHours, sumExpTime, weatherLoss) => {
   let eff = 0.0;
   if (nightHours !== 0) {

--- a/src/utils/fetchUtils.jsx
+++ b/src/utils/fetchUtils.jsx
@@ -14,4 +14,27 @@ const calculateEfficiency = (nightHours, sumExpTime, weatherLoss) => {
   return eff === 0 ? 0 : eff.toFixed(2);
 };
 
-export { calculateEfficiency };
+/**
+ * Calculates the total time loss and provides a breakdown of the loss due to weather and faults.
+ *
+ * @param {number} weatherLoss - The amount of time lost due to weather (in seconds).
+ * @param {number} faultLoss - The amount of time lost due to faults (in seconds).
+ * @returns {[string, string]} A tuple where the first element is the total time loss as a string (e.g., "5 seconds"),
+ * and the second element is a string detailing the percentage breakdown of weather and fault losses.
+ */
+const calculateTimeLoss = (weatherLoss, faultLoss) => {
+  let loss = weatherLoss + faultLoss;
+
+  let timeLoss = "0 hours";
+  let timeLossDetails = "(- weather; - fault)";
+
+  if (loss > 0) {
+    let weatherPercent = (weatherLoss / loss) * 100;
+    let faultPercent = (faultLoss / loss) * 100;
+    timeLoss = `${loss} hours`;
+    timeLossDetails = `(${weatherPercent}% weather; ${faultPercent}% fault)`;
+  }
+
+  return timeLoss, timeLossDetails;
+};
+export { calculateEfficiency, calculateTimeLoss };


### PR DESCRIPTION
Update the nightly digest frontend to fetch data using data source adapters; Almanac, ConsDB and Narrative Log.
Currently the following metrics cards on top of the page retrieve data from the data source adapters:
- The exposures metrics card (expected no of exposures is still TBD)
- Telescope Efficiency metrics card
- Time Loss metrics card

The no of tickets in Jira metrics card is TBD