### PR TITLE
DM-500962: Make the telescope selector box say "Telescope:" instead of "Instrument:"

### DIFF
--- a/src/components/app-sidebar.jsx
+++ b/src/components/app-sidebar.jsx
@@ -69,8 +69,8 @@ export function AppSidebar({ ...props }) {
               onStartDayChange={props.onStartDayChange}
               endDay={props.endDay}
               onEndDayChange={props.onEndDayChange}
-              instrument={props.instrument}
-              onInstrumentChange={props.onInstrumentChange}
+              telescope={props.telescope}
+              onTelescopeChange={props.onTelescopeChange}
             />
           </SidebarGroupContent>
         </SidebarGroup>

--- a/src/components/parameters.jsx
+++ b/src/components/parameters.jsx
@@ -9,7 +9,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { DatePicker } from "@/components/ui/datepicker.jsx";
 
-const instruments = [
+const telescopes = [
   {
     value: "simonyi",
     label: "Simonyi",
@@ -25,27 +25,27 @@ function Parameters({
   endDay,
   onStartDayChange,
   onEndDayChange,
-  instrument,
-  onInstrumentChange,
+  telescope,
+  onTelescopeChange,
 }) {
   return (
     <>
       <div className="pt-3">
-        <Label htmlFor="instrument" className="text-white text-base pb-1">
+        <Label htmlFor="telescope" className="text-white text-base pb-1">
           {" "}
-          Instrument:{" "}
+          Telescope:{" "}
         </Label>
-        <Select value={instrument} onValueChange={onInstrumentChange}>
+        <Select value={telescope} onValueChange={onTelescopeChange}>
           <SelectTrigger
-            id="instrument"
+            id="telescope"
             className="w-[200px] bg-white justify-between font-normal rounded-s shadow-[4px_4px_4px_0px_#3CAE3F] focus-visible:ring-4 focus-visible:ring-green-500/50"
           >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {instruments.map((instr) => (
-              <SelectItem key={instr.value} value={instr.value}>
-                {instr.label}
+            {telescopes.map((tel) => (
+              <SelectItem key={tel.value} value={tel.value}>
+                {tel.label}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/pages/layout.jsx
+++ b/src/pages/layout.jsx
@@ -14,14 +14,14 @@ export default function Layout({ children }) {
   const [nooftickets, setNooftickets] = useState(0);
   const [dayObsStart, setDayObsStart] = useState(new Date());
   const [dayObsEnd, setDayObsEnd] = useState(new Date());
-  const [instrument, setInstrument] = useState("auxtel");
+  const [telescope, setTelescope] = useState("auxtel");
 
   useEffect(() => {
     async function fetchJiraTickets() {
       let start = dayObsStart.toISOString().split("T")[0];
       let end = dayObsEnd.toISOString().split("T")[0];
       const res = await fetch(
-        `http://0.0.0.0:8000/jira-tickets?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`,
+        `http://0.0.0.0:8000/jira-tickets?dayObsStart=${start}&dayObsEnd=${end}&telescope=${telescope}`,
         {
           method: "GET",
           headers: {
@@ -38,7 +38,7 @@ export default function Layout({ children }) {
     }
 
     fetchJiraTickets();
-  }, [dayObsStart, dayObsEnd, instrument]);
+  }, [dayObsStart, dayObsEnd, telescope]);
 
   return (
     <>
@@ -48,8 +48,8 @@ export default function Layout({ children }) {
           onStartDayChange={setDayObsStart}
           endDay={dayObsEnd}
           onEndDayChange={setDayObsEnd}
-          instrument={instrument}
-          onInstrumentChange={setInstrument}
+          telescope={telescope}
+          onTelescopeChange={setTelescope}
         />
         <main className="w-full bg-stone-800">
           {/* Show/Hide Sidebar button */}


### PR DESCRIPTION
This PR renames all instances of the instrument input parameter to be "telescope" (or "telescopes") in line with the options provided to the user of Simonyi and Auxtel.