### PR TITLE
OSW- 647 Reduce decimal points

### DIFF
--- a/doc/news/OSW-647.misc.rst
+++ b/doc/news/OSW-647.misc.rst
@@ -1,0 +1,1 @@
+Remove decimal points from time loss and efficiency cards

--- a/doc/news/OSW-648.bugfix.rst
+++ b/doc/news/OSW-648.bugfix.rst
@@ -1,0 +1,1 @@
+Make the jira tickets table scrollable and use sticky headers. Also make the popup wider to stop columns from running into each other. 

--- a/src/components/dialog-metrics-card.jsx
+++ b/src/components/dialog-metrics-card.jsx
@@ -41,7 +41,7 @@ function DialogMetricsCard({
           className="bg-sky-750 text-white font-light p-4 rounded-lg
                shadow-[0px_4px_4px_0px_#00000040,4px_4px_16px_4px_#006DA8B2]
                border-4 border-[#0C4A47] p-8
-               !w-[90vw] !max-w-5xl"
+               !w-[95vw] !max-w-7xl "
         >
           <DialogHeader>
             <DialogTitle className="flex flex-row text-2xl justify-between">

--- a/src/components/jira-tickets-table.jsx
+++ b/src/components/jira-tickets-table.jsx
@@ -11,67 +11,86 @@ import LinkIcon from "../assets/LinkIcon.svg";
 
 function JiraTicketsTable({ tickets, loading = false }) {
   return (
-    <div className="overflow-x-auto">
-      <Table className="w-full">
+    <div className="w-full">
+      <Table className="w-full table-fixed">
         <TableHeader>
-          <TableRow className="[&>th]:!text-white [&>th]:text-lg">
-            <TableHead>Number</TableHead>
-            <TableHead colSpan={3}>Summary</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Created</TableHead>
-            <TableHead>Last Updated</TableHead>
-            <TableHead className="text-right">Link</TableHead>
+          <TableRow>
+            <TableHead className="sticky top-0 z-10 !text-white text-lg">
+              Number
+            </TableHead>
+            <TableHead
+              colSpan={2}
+              className="sticky top-0 z-10 !text-white text-lg"
+            >
+              Summary
+            </TableHead>
+            <TableHead className="sticky top-0 z-10 !text-white text-lg">
+              Status
+            </TableHead>
+            <TableHead className="sticky top-0 z-10 !text-white text-lg">
+              Created
+            </TableHead>
+            <TableHead className="sticky top-0 z-10 !text-white text-lg">
+              Last Updated
+            </TableHead>
+            <TableHead className="sticky top-0 z-10 !text-white text-lg text-right">
+              Link
+            </TableHead>
           </TableRow>
         </TableHeader>
-        <TableBody>
-          {loading ? (
-            <TableRow>
-              <TableCell colSpan={8} className="text-center">
-                Loading tickets...
-              </TableCell>
-            </TableRow>
-          ) : tickets.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={8} className="text-center">
-                No tickets found.
-              </TableCell>
-            </TableRow>
-          ) : (
-            tickets.map((ticket) => (
-              <TableRow key={ticket.key}>
-                <TableCell className="font-medium">
-                  <span>{ticket.key}</span>
-                  {ticket.isNew && (
-                    <span className="ml-1 bg-amber-500 text-black text-xs p-1 rounded-full">
-                      New
-                    </span>
-                  )}
-                </TableCell>
-                <TableCell colSpan={3} className="!text-wrap break-normal">
-                  {ticket.summary}
-                </TableCell>
-                <TableCell>{ticket.status}</TableCell>
-                <TableCell>{ticket.created}</TableCell>
-                <TableCell>{ticket.updated}</TableCell>
-                <TableCell className="text-right">
-                  <a
-                    href={ticket.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 hover:underline"
-                  >
-                    <img
-                      src={LinkIcon}
-                      alt="View Ticket"
-                      className="inline-block w-6 h-6"
-                    />
-                  </a>
+      </Table>
+      <div className="max-h-96 overflow-y-auto w-full">
+        <Table className="w-full table-fixed">
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center">
+                  Loading tickets...
                 </TableCell>
               </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
+            ) : tickets.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center">
+                  No tickets found.
+                </TableCell>
+              </TableRow>
+            ) : (
+              tickets.map((ticket) => (
+                <TableRow key={ticket.key}>
+                  <TableCell className="font-medium">
+                    <span>{ticket.key}</span>
+                    {ticket.isNew && (
+                      <span className="ml-1 bg-amber-500 text-black text-xs p-1 rounded-full">
+                        New
+                      </span>
+                    )}
+                  </TableCell>
+                  <TableCell colSpan={2} className="!text-wrap break-normal">
+                    {ticket.summary}
+                  </TableCell>
+                  <TableCell>{ticket.status}</TableCell>
+                  <TableCell>{ticket.created}</TableCell>
+                  <TableCell>{ticket.updated}</TableCell>
+                  <TableCell className="text-right">
+                    <a
+                      href={ticket.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:underline"
+                    >
+                      <img
+                        src={LinkIcon}
+                        alt="View Ticket"
+                        className="inline-block w-6 h-6"
+                      />
+                    </a>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
     </div>
   );
 }

--- a/src/components/jira-tickets-table.jsx
+++ b/src/components/jira-tickets-table.jsx
@@ -70,7 +70,7 @@ function JiraTicketsTable({ tickets, loading = false }) {
                   </TableCell>
                   <TableCell>{ticket.status}</TableCell>
                   <TableCell className="!text-wrap">{ticket.created}</TableCell>
-                  <TableCell>{ticket.updated}</TableCell>
+                  <TableCell className="!text-wrap">{ticket.updated}</TableCell>
                   <TableCell className="text-right">
                     <a
                       href={ticket.url}

--- a/src/components/jira-tickets-table.jsx
+++ b/src/components/jira-tickets-table.jsx
@@ -69,7 +69,7 @@ function JiraTicketsTable({ tickets, loading = false }) {
                     {ticket.summary}
                   </TableCell>
                   <TableCell>{ticket.status}</TableCell>
-                  <TableCell>{ticket.created}</TableCell>
+                  <TableCell className="!text-wrap">{ticket.created}</TableCell>
                   <TableCell>{ticket.updated}</TableCell>
                   <TableCell className="text-right">
                     <a

--- a/src/utils/utils.jsx
+++ b/src/utils/utils.jsx
@@ -13,7 +13,7 @@ const calculateEfficiency = (nightHours, sumExpTime, weatherLoss) => {
   if (nightHours !== 0) {
     eff = (100 * sumExpTime) / (nightHours * 60 * 60 - weatherLoss);
   }
-  return eff === 0 ? 0 : eff.toFixed(2);
+  return eff === 0 ? 0 : Math.round(eff);
 };
 
 /**
@@ -30,8 +30,8 @@ const calculateTimeLoss = (weatherLoss, faultLoss) => {
   let timeLossDetails = "(- weather; - fault)";
 
   if (loss > 0) {
-    let weatherPercent = (weatherLoss / loss) * 100;
-    let faultPercent = (faultLoss / loss) * 100;
+    let weatherPercent = Math.round((weatherLoss / loss) * 100);
+    let faultPercent = Math.round((faultLoss / loss) * 100);
     timeLoss = `${loss.toFixed(2)} hours`;
     timeLossDetails = `(${weatherPercent}% weather; ${faultPercent}% fault)`;
   }


### PR DESCRIPTION
Remove decimal points from time loss and efficiency cards.
Make the jira tickets table scrollable and use sticky headers. Also make the popup wider to stop columns from running into each other. 