### PR TITLE
OSW-541 Update exposure count card in nightly digest to reflect can_see_sky

### DIFF
--- a/doc/news/OSW-541.feature.rst
+++ b/doc/news/OSW-541.feature.rst
@@ -1,0 +1,1 @@
+Grab on-sky exposures count and total on-sky exposure time from response in fetchExposures and use them in the no of exposures and efficiency metric cards

--- a/src/pages/digest.jsx
+++ b/src/pages/digest.jsx
@@ -37,6 +37,8 @@ export default function Digest() {
   const [exposureFields, setExposureFields] = useState([]);
   const [exposureCount, setExposureCount] = useState(0);
   const [sumExpTime, setSumExpTime] = useState(0.0);
+  const [onSkyExpCount, setOnSkyExpCount] = useState(0);
+  const [sumOnSkyExpTime, setSumOnSkyExpTime] = useState(0.0);
   const [flags, setFlags] = useState([]);
 
   const [exposuresLoading, setExposuresLoading] = useState(true);
@@ -63,10 +65,13 @@ export default function Digest() {
     setFlagsLoading(true);
 
     fetchExposures(startDayobs, queryEndDayobs, instrument, abortController)
-      .then(([exposureFields, exposuresNo, exposureTime]) => {
+      .then(([exposureFields, exposuresNo, exposureTime, onSkyExpNo,
+          totalOnSkyExpTime]) => {
         setExposureFields(exposureFields);
         setExposureCount(exposuresNo);
         setSumExpTime(exposureTime);
+        setOnSkyExpCount(onSkyExpNo);
+        setSumOnSkyExpTime(totalOnSkyExpTime);
         setExposuresLoading(false);
         if (exposuresNo === 0) {
           toast.warning("No exposures found for the selected date range.");
@@ -179,7 +184,7 @@ export default function Digest() {
   }, [startDayobs, endDayobs, telescope]);
 
   // calculate open shutter efficiency
-  const efficiency = calculateEfficiency(nightHours, sumExpTime, weatherLoss);
+  const efficiency = calculateEfficiency(nightHours, sumOnSkyExpTime, weatherLoss);
   const efficiencyText = `${efficiency} %`;
   const [timeLoss, timeLossDetails] = calculateTimeLoss(weatherLoss, faultLoss);
   const newTicketsCount = jiraTickets.filter((tix) => tix.isNew).length;
@@ -191,7 +196,7 @@ export default function Digest() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
           <MetricsCard
             icon={ShutterIcon}
-            data={exposureCount}
+            data={onSkyExpCount}
             label="Nighttime exposures taken"
             metadata="(TBD expected)"
             tooltip="On-sky exposures taken during the specified date range."
@@ -201,7 +206,7 @@ export default function Digest() {
             icon={<EfficiencyChart value={efficiency} />}
             data={efficiencyText}
             label="Open-shutter (-weather) efficiency"
-            tooltip="Efficiency computed as total exposure time / (time between 18 degree twilights minus time lost to weather)"
+            tooltip="Efficiency computed as total on-sky exposure time / (time between 18 degree twilights minus time lost to weather)"
             loading={almanacLoading || exposuresLoading}
           />
           <MetricsCard

--- a/src/pages/digest.jsx
+++ b/src/pages/digest.jsx
@@ -65,18 +65,25 @@ export default function Digest() {
     setFlagsLoading(true);
 
     fetchExposures(startDayobs, queryEndDayobs, instrument, abortController)
-      .then(([exposureFields, exposuresNo, exposureTime, onSkyExpNo,
-          totalOnSkyExpTime]) => {
-        setExposureFields(exposureFields);
-        setExposureCount(exposuresNo);
-        setSumExpTime(exposureTime);
-        setOnSkyExpCount(onSkyExpNo);
-        setSumOnSkyExpTime(totalOnSkyExpTime);
-        setExposuresLoading(false);
-        if (exposuresNo === 0) {
-          toast.warning("No exposures found for the selected date range.");
-        }
-      })
+      .then(
+        ([
+          exposureFields,
+          exposuresNo,
+          exposureTime,
+          onSkyExpNo,
+          totalOnSkyExpTime,
+        ]) => {
+          setExposureFields(exposureFields);
+          setExposureCount(exposuresNo);
+          setSumExpTime(exposureTime);
+          setOnSkyExpCount(onSkyExpNo);
+          setSumOnSkyExpTime(totalOnSkyExpTime);
+          setExposuresLoading(false);
+          if (exposuresNo === 0) {
+            toast.warning("No exposures found for the selected date range.");
+          }
+        },
+      )
       .catch((err) => {
         if (!abortController.signal.aborted) {
           const msg = err?.message;
@@ -184,7 +191,11 @@ export default function Digest() {
   }, [startDayobs, endDayobs, telescope]);
 
   // calculate open shutter efficiency
-  const efficiency = calculateEfficiency(nightHours, sumOnSkyExpTime, weatherLoss);
+  const efficiency = calculateEfficiency(
+    nightHours,
+    sumOnSkyExpTime,
+    weatherLoss,
+  );
   const efficiencyText = `${efficiency} %`;
   const [timeLoss, timeLossDetails] = calculateTimeLoss(weatherLoss, faultLoss);
   const newTicketsCount = jiraTickets.filter((tix) => tix.isNew).length;

--- a/src/utils/fetchUtils.jsx
+++ b/src/utils/fetchUtils.jsx
@@ -60,7 +60,13 @@ const fetchExposures = async (start, end, instrument, abortController) => {
   try {
     const url = `${backendLocation}/exposures?dayObsStart=${start}&dayObsEnd=${end}&instrument=${instrument}`;
     const data = await fetchData(url, abortController);
-    return [data.exposures, data.exposures_count, data.sum_exposure_time];
+    return [
+      data.exposures,
+      data.exposures_count,
+      data.sum_exposure_time,
+      data.on_sky_exposures_count,
+      data.total_on_sky_exposure_time,
+    ];
   } catch (err) {
     if (err.name !== "AbortError") {
       console.error("Error fetching exposures:", err);


### PR DESCRIPTION
Grab no of on-sky exposures and total on-sky exp time from response in fetchExposures and use them in the no of exposures and efficiency metric cards.
This PR depends on this [backend PR](https://github.com/lsst-ts/ts_logging_and_reporting/pull/54)