### PR TITLE
Move VITE_EXTERNAL_INSTANCE_URL to docker build args in compose.

### DIFF
--- a/doc/news/OSW-702.bugfix.rst
+++ b/doc/news/OSW-702.bugfix.rst
@@ -1,0 +1,1 @@
+Move VITE_EXTERNAL_INSTANCE_URL to docker build args in compose

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,9 +6,9 @@ services:
     build:
       context: ${FRONTEND_PATH}
       dockerfile: docker/Dockerfile
+      args:
+        - VITE_EXTERNAL_INSTANCE_URL=${EXTERNAL_INSTANCE_URL}
     image: nightlydigest-frontend-local
-    environment:
-      - VITE_EXTERNAL_INSTANCE_URL=${EXTERNAL_INSTANCE_URL}
     ports:
       - "5173:5173"
     volumes:


### PR DESCRIPTION
Make the env variable a build variable, not runtime. 