### PR TITLE
OSW-994 Tighten conditions for inter-exposure gaps

### DIFF
--- a/doc/news/OSW-994.misc.rst
+++ b/doc/news/OSW-994.misc.rst
@@ -1,0 +1,1 @@
+In observing conditions applet, don't show gaps if the exposure is off sky or if psf_median and zero_point_median are null 

--- a/src/components/ObservingConditionsApplet.jsx
+++ b/src/components/ObservingConditionsApplet.jsx
@@ -355,7 +355,7 @@ function ObservingConditionsApplet({
   // A gap is defined as a period longer than GAP_THRESHOLD (5 minutes)
   const gapAreas = useMemo(() => {
     const gaps = [];
-    for (const [_, all_exps] of Object.entries(groupedByDayobs)) {
+    for (const all_exps of Object.values(groupedByDayobs)) {
       const exps = all_exps.filter(
         (d) =>
           isValidNumber(d.psf_median) && isValidNumber(d.zero_point_median),


### PR DESCRIPTION
In observing conditions applet, don't show gaps if the exposure is off sky or if psf_median and zero_point_median are null