### PR TITLE
OSW-1255: Add new date/time columns to Context Feed table.

### DIFF
--- a/doc/news/OSW-1255.feature.rst
+++ b/doc/news/OSW-1255.feature.rst
@@ -1,0 +1,1 @@
+Make several new date/time columns available to display in the Context Feed table.

--- a/src/components/ContextFeedColumns.jsx
+++ b/src/components/ContextFeedColumns.jsx
@@ -20,12 +20,13 @@ import FullScreenIcon from "../assets/FullScreenIcon.svg";
 
 const columnHelper = createColumnHelper();
 
-// Helper function to make time columns more readable
+// Helper function to make time columns more readable.
+// Default zone is UTC; otherwise pass in IANA identifier.
 // Luxon only natively supports millisecond precision, not microseconds.
 // Will need to extract microseconds if this precision is required.
-function formatTimestamp(tsString) {
+function formatTimestamp(tsString, tsZone = "utc") {
   if (!tsString) return null;
-  const dt = DateTime.fromISO(tsString, { zone: "utc" });
+  const dt = DateTime.fromISO(tsString, { zone: tsZone });
   return dt.isValid ? dt.toFormat("yyyy-LL-dd HH:mm:ss.S") : tsString;
 }
 
@@ -304,7 +305,11 @@ export const defaultColumnVisibility = {
   category_index: false,
   event_type: true,
   current_task: false,
+  event_date: false,
+  event_dayobs: false,
   time: true,
+  event_time_tai: false,
+  event_time_chile: false,
   name: true,
   description: true,
   config: true,
@@ -321,7 +326,11 @@ export const defaultColumnOrder = [
   "category_index",
   "event_type",
   "current_task",
+  "event_date",
+  "event_dayobs",
   "time",
+  "event_time_tai",
+  "event_time_chile",
   "name",
   "description",
   "config",
@@ -381,6 +390,28 @@ export const contextFeedColumns = [
       tooltip: "BLOCK or FBS configuration.",
     },
   }),
+  columnHelper.accessor("event_date", {
+    header: "Date",
+    cell: (info) => info.getValue(),
+    size: 120,
+    minSize: 100,
+    filterFn: matchValueOrInList,
+    filterType: "string",
+    meta: {
+      tooltip: "Date of event.",
+    },
+  }),
+  columnHelper.accessor("event_dayobs", {
+    header: "Dayobs",
+    cell: (info) => info.getValue(),
+    size: 120,
+    minSize: 100,
+    filterFn: matchValueOrInList,
+    filterType: "string",
+    meta: {
+      tooltip: "Dayobs of event.",
+    },
+  }),
   columnHelper.accessor("time", {
     header: "Time (UTC)",
     cell: (info) => formatTimestamp(info.getValue()),
@@ -388,7 +419,27 @@ export const contextFeedColumns = [
     minSize: 220,
     filterType: "number-range",
     meta: {
-      tooltip: "Time associated with event.",
+      tooltip: "Time (UTC) associated with event.",
+    },
+  }),
+  columnHelper.accessor("event_time_tai", {
+    header: "Time (TAI)",
+    cell: (info) => formatTimestamp(info.getValue()),
+    size: 220,
+    minSize: 220,
+    filterType: "number-range",
+    meta: {
+      tooltip: "Time (TAI) associated with event.",
+    },
+  }),
+  columnHelper.accessor("event_time_chile", {
+    header: "Time (Chile)",
+    cell: (info) => formatTimestamp(info.getValue(), "America/Santiago"),
+    size: 220,
+    minSize: 220,
+    filterType: "number-range",
+    meta: {
+      tooltip: "Time (Chile) associated with event.",
     },
   }),
   columnHelper.accessor("name", {

--- a/src/components/DataLogColumns.jsx
+++ b/src/components/DataLogColumns.jsx
@@ -4,7 +4,6 @@ import {
   formatCellValue,
   DEFAULT_PIXEL_SCALE_MEDIAN,
   PSF_SIGMA_FACTOR,
-  getZephyrUrl,
 } from "@/utils/utils";
 import { matchValueOrInList } from "@/components/DataTable/tableUtils";
 

--- a/src/components/DataLogColumns.jsx
+++ b/src/components/DataLogColumns.jsx
@@ -4,6 +4,7 @@ import {
   formatCellValue,
   DEFAULT_PIXEL_SCALE_MEDIAN,
   PSF_SIGMA_FACTOR,
+  getZephyrUrl,
 } from "@/utils/utils";
 import { matchValueOrInList } from "@/components/DataTable/tableUtils";
 

--- a/src/utils/timeUtils.js
+++ b/src/utils/timeUtils.js
@@ -94,21 +94,15 @@ const getDayobsEndUTC = (dayobsStr) => {
 /**
  * Converts a Luxon DateTime object in UTC to a string in "yyyy-LL-dd" format.
  *
- * Each dayobs ends at midday UTC the next day, so if the DateTime is in the AM,
- * the dayobs is set as the previous day's date.
+ * Each dayobs ends at midday UTC the next day, so times in the AM belong to the
+ * previous day's observations. This is implemented by subtracting 12 hours before
+ * taking the date.
  *
  * @param {DateTime} dateTimeUTC - A Luxon DateTime object in UTC.
  * @returns {string} The dayobs date string in "yyyy-LL-dd" format (e.g., "2025-08-27").
  */
-const getDayobsUTC = (dateTimeUTC) => {
-  const date = dateTimeUTC.startOf("day");
-  // If time before midday, take one day
-  return (
-    dateTimeUTC < getDayobsStartUTC(date.toFormat("yyyyLLdd"))
-      ? date.minus({ days: 1 })
-      : date
-  ).toFormat("yyyy-LL-dd");
-};
+const getDayobsUTC = (dateTimeUTC) =>
+  dateTimeUTC.toUTC().minus({ hours: 12 }).toFormat("yyyy-LL-dd");
 
 /**
  * Adjusts an almanac-provided dayobs number to the plotting convention.

--- a/src/utils/timeUtils.js
+++ b/src/utils/timeUtils.js
@@ -4,7 +4,7 @@ const TAI_OFFSET_SECONDS = 37;
 const ISO_DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss"; // Twilight time format string
 
 /**
- * Converts an ISO 8601 string (representing TAI time) to a Luxon DateTime object in TAI.
+ * Converts an ISO 8601 string to a Luxon DateTime object in TAI.
  *
  * Parses the string as UTC and applies the 37-second TAI offset.
  *
@@ -23,6 +23,15 @@ const isoToTAI = (isoStr) =>
  * @returns {DateTime} A Luxon DateTime object in UTC.
  */
 const isoToUTC = (isoStr) => DateTime.fromISO(isoStr, { zone: "utc" });
+
+/**
+ * Converts an ISO 8601 string to a Luxon DateTime object in Chilean Time.
+ *
+ * @param {string} isoStr - The ISO date-time string (e.g., "2025-08-27T12:34:56Z").
+ * @returns {DateTime} A Luxon DateTime object in Chilean Time.
+ */
+const isoToChile = (isoStr) =>
+  DateTime.fromISO(isoStr, { zone: "America/Santiago" });
 
 /**
  * Converts a dayobs string to the "start" boundary (12:00 noon) in TAI.
@@ -80,6 +89,25 @@ const getDayobsEndUTC = (dayobsStr) => {
     zone: "utc",
   });
   return dayobsDate.plus({ days: 1 }).set({ hour: 11, minute: 59, second: 59 });
+};
+
+/**
+ * Converts a Luxon DateTime object in UTC to a string in "yyyy-LL-dd" format.
+ *
+ * Each dayobs ends at midday UTC the next day, so if the DateTime is in the AM,
+ * the dayobs is set as the previous day's date.
+ *
+ * @param {DateTime} dateTimeUTC - A Luxon DateTime object in UTC.
+ * @returns {string} The dayobs date string in "yyyy-LL-dd" format (e.g., "2025-08-27").
+ */
+const getDayobsUTC = (dateTimeUTC) => {
+  const date = dateTimeUTC.startOf("day");
+  // If time before midday, take one day
+  return (
+    dateTimeUTC < getDayobsStartUTC(date.toFormat("yyyyLLdd"))
+      ? date.minus({ days: 1 })
+      : date
+  ).toFormat("yyyy-LL-dd");
 };
 
 /**
@@ -266,10 +294,12 @@ function utcDateToCalendarDate(utcDate) {
 export {
   isoToTAI,
   isoToUTC,
+  isoToChile,
   getDayobsStartTAI,
   getDayobsEndTAI,
   getDayobsStartUTC,
   getDayobsEndUTC,
+  getDayobsUTC,
   almanacDayobsForPlot,
   millisToDateTime,
   millisToHHmm,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -3,7 +3,9 @@ import {
   TAI_OFFSET_SECONDS,
   ISO_DATETIME_FORMAT,
   getDayobsStartUTC,
-  isoToUTC,
+  isoToTAI,
+  isoToChile,
+  getDayobsUTC,
 } from "./timeUtils";
 import { CATEGORY_INDEX_INFO } from "@/components/context-feed-definitions.js";
 import { GLOBAL_SEARCH_PARAMS } from "@/routes";
@@ -299,10 +301,17 @@ const mergeContextFeedSources = (rubinNightsRows, blockLookup) => {
         // Get display info for each category
         let categoryInfo = CATEGORY_INDEX_INFO[entry.category_index] || {};
 
+        // Get Luxon DateTime object
+        const timeUTC = isoToUTC(entry["time"]);
+
         return {
           ...entry,
-          event_time_dt: isoToUTC(entry["time"]),
-          event_time_millis: isoToUTC(entry["time"]).toMillis(),
+          event_time_dt: timeUTC,
+          event_date: timeUTC.toFormat("yyyy-LL-dd"),
+          event_dayobs: getDayobsUTC(timeUTC),
+          event_time_millis: timeUTC.toMillis(),
+          event_time_tai: isoToTAI(entry["time"]),
+          event_time_chile: isoToChile(entry["time"]),
           event_type: categoryInfo.label,
           event_color: categoryInfo.color ?? "#ffffff",
           displayIndex: categoryInfo.displayIndex,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -214,6 +214,7 @@ const inferDecimals = (value) => {
  * @param {Object{}} blockLookup - The dict of BLOCK objects from Zephyr/Jira.
  * @returns {Object[]} A new array of merged row objects with added/enriched fields.
  */
+
 const mergeAllDataLogSources = (consDbRows, exposureLogRows, blockLookup) => {
   // Build fast lookup map for exposure log
   const exposureLogMap = new Map();

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -5,6 +5,7 @@ import {
   getDayobsStartUTC,
   isoToTAI,
   isoToChile,
+  isoToUTC,
   getDayobsUTC,
 } from "./timeUtils";
 import { CATEGORY_INDEX_INFO } from "@/components/context-feed-definitions.js";

--- a/tests/timeUtils.test.js
+++ b/tests/timeUtils.test.js
@@ -8,6 +8,7 @@ import {
   getDayobsEndTAI,
   getDayobsStartUTC,
   getDayobsEndUTC,
+  getDayobsUTC,
   almanacDayobsForPlot,
   millisToDateTime,
   millisToHHmm,
@@ -60,6 +61,20 @@ describe("timeUtils", () => {
     it("returns 11:59 next day UTC for the given dayobs", () => {
       const dt = getDayobsEndUTC("20250818");
       expect(dt.toISO()).toBe("2025-08-19T11:59:59.000Z");
+    });
+  });
+
+  describe("getDayobsUTC", () => {
+    it("returns the previous day if the time is before midday UTC", () => {
+      const dt = DateTime.fromISO("2025-08-19T09:00:00Z");
+      const dayobs = getDayobsUTC(dt);
+      expect(dayobs).toBe("2025-08-18");
+    });
+
+    it("returns the same day if the time is after midday UTC", () => {
+      const dt = DateTime.fromISO("2025-08-19T15:00:00Z");
+      const dayobs = getDayobsUTC(dt);
+      expect(dayobs).toBe("2025-08-19");
     });
   });
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -478,7 +478,7 @@ describe("utils", () => {
       expect(merged[1].current_task).toBe("BLOCK-T100");
     });
 
-    it("adds derived event_time_millis", () => {
+    it("adds derived time fields", () => {
       const rubinRows = [
         baseRow({
           time: "2025-01-01T00:00:00Z",
@@ -488,6 +488,13 @@ describe("utils", () => {
       const merged = mergeContextFeedSources(rubinRows, {});
 
       expect(merged[0].event_time_millis).toBe(1735689600000);
+
+      // New derived fields
+      expect(merged[0].event_time_dt.toISO()).toBe("2025-01-01T00:00:00.000Z");
+      expect(merged[0].event_date).toBe("2025-01-01");
+      expect(merged[0].event_dayobs).toBe("2024-12-31"); // before midday UTC
+      expect(merged[0].event_time_tai).toBeDefined();
+      expect(merged[0].event_time_chile).toBeDefined();
     });
 
     it("sorts rows chronologically by event_time_millis", () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -22,6 +22,7 @@ import {
   parseBackendVersion,
   getZephyrUrl,
 } from "@/utils/utils";
+
 import { getDayobsStartUTC } from "@/utils/timeUtils";
 import { CATEGORY_INDEX_INFO } from "@/components/context-feed-definitions.js";
 import { GLOBAL_SEARCH_PARAMS } from "@/routes";


### PR DESCRIPTION
This adds several new columns to the Context Feed table, all hidden by default:
 - event_date
 - event_dayobs
 - event_time_tai
 - event_time_chile
 
Needs to be merged after [OSW-850](https://github.com/lsst-ts/ts_logging_frontend/tree/tickets/OSW-850).

[OSW-850]: https://rubinobs.atlassian.net/browse/OSW-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ