### PR TITLE
OSW-1004: Exposure Breakdown hover highlights data in Observing Conditions

### DIFF
--- a/doc/news/OSW-1004.feature.rst
+++ b/doc/news/OSW-1004.feature.rst
@@ -1,0 +1,1 @@
+Hovering a bar in the Exposure Breakdown applet now highlights the corresponding observations in the Observing Conditions applet.

--- a/src/components/ExposureBreakdownApplet.jsx
+++ b/src/components/ExposureBreakdownApplet.jsx
@@ -273,7 +273,7 @@ function ExposureBreakdownApplet({
             </PopoverTrigger>
             <PopoverContent className="bg-black text-white text-sm border-yellow-700 w-[300px]">
               This applet displays a breakdown of exposures taken during the
-              night, grouped by a selected field.
+              specified dayobs range, grouped by a selected field.
               <br />
               <br />
               The chart can be configured to show either the{" "}
@@ -289,7 +289,7 @@ function ExposureBreakdownApplet({
               <ul className="list-disc pl-4 mt-1 space-y-1">
                 <li>
                   Hover over a bar to view total and flagged values, and
-                  highlight the corresponding observations in the{" "}
+                  highlight the corresponding exposures in the{" "}
                   <strong>Observing Conditions</strong> chart.
                 </li>
                 <li>
@@ -298,7 +298,8 @@ function ExposureBreakdownApplet({
                   documentation.
                 </li>
                 <li>
-                  Click a bar to open the Data Log, filtered by that group.
+                  Click a bar to open the <strong>Data Log</strong>, filtered by
+                  that group.
                 </li>
                 <li>Scroll to see additional groups if all are not visible.</li>
               </ul>

--- a/src/components/ExposureBreakdownApplet.jsx
+++ b/src/components/ExposureBreakdownApplet.jsx
@@ -58,6 +58,8 @@ function ExposureBreakdownApplet({
   blockLookup = {},
   exposuresLoading = false,
   flagsLoading = false,
+  onBarHover,
+  onBarLeave,
 }) {
   const [plotBy, setPlotBy] = useState(PlotByValues.NUMBER);
   const [groupBy, setGroupBy] = useState(GroupByValues.SCIENCE_PROGRAM);
@@ -158,8 +160,10 @@ function ExposureBreakdownApplet({
               groupKey,
               unflagged: 0,
               flagged: 0,
+              exposureIds: [],
             };
           }
+          aggregatedMap[groupKey].exposureIds.push(String(row.exposure_id));
 
           if (plotBy === PlotByValues.TIME) {
             if (isFlagged) {
@@ -189,6 +193,7 @@ function ExposureBreakdownApplet({
           groupKey: entry.groupKey,
           unflagged: entry.unflagged,
           flagged: entry.flagged,
+          exposureIds: entry.exposureIds,
           totalValue,
         };
       });
@@ -282,7 +287,11 @@ function ExposureBreakdownApplet({
               <br />
               <strong>Tips:</strong>
               <ul className="list-disc pl-4 mt-1 space-y-1">
-                <li>Hover over a bar to view total and flagged values.</li>
+                <li>
+                  Hover over a bar to view total and flagged values, and
+                  highlight the corresponding observations in the{" "}
+                  <strong>Observing Conditions</strong> chart.
+                </li>
                 <li>
                   In <strong>Science Program</strong> view, hover to see the
                   BLOCK description (if available). Linked labels open the BLOCK
@@ -372,6 +381,7 @@ function ExposureBreakdownApplet({
                               if (tooltipState !== null) {
                                 setTooltipState(null);
                                 setHovered(null);
+                                onBarLeave?.();
                               }
                               return;
                             }
@@ -386,11 +396,16 @@ function ExposureBreakdownApplet({
                                 groupKey,
                               });
                               setHovered(groupKey);
+                              const entry = chartData.find(
+                                (d) => d.groupKey === groupKey,
+                              );
+                              onBarHover?.(entry?.exposureIds ?? []);
                             }
                           }}
                           onMouseLeave={() => {
                             setTooltipState(null);
                             setHovered(null);
+                            onBarLeave?.();
                           }}
                         >
                           {/* Unflagged data stacked bar (bottom) */}

--- a/src/components/ObservingConditionsApplet.jsx
+++ b/src/components/ObservingConditionsApplet.jsx
@@ -226,6 +226,7 @@ function ObservingConditionsApplet({
   fullTimeRange,
   selectedTimeRange,
   setSelectedTimeRange,
+  hoveredExposureIds = null,
 }) {
   // Router and search params for context menu navigation
   const search = useSearch({ from: "/" });
@@ -261,21 +262,6 @@ function ObservingConditionsApplet({
   // Convert selected time range to millis for ReferenceArea
   const selectedMinMillis = selectedTimeRange?.[0]?.toMillis();
   const selectedMaxMillis = selectedTimeRange?.[1]?.toMillis();
-
-  // opacity for each band based on hovering state
-  // if hoveredBand is set, the opacity for that band is 1, otherwise it
-  // is set to 0 to hide the line
-
-  const opacity = useMemo(() => {
-    return {
-      u: hoveredBand && hoveredBand !== "u" ? 0 : 1,
-      r: hoveredBand && hoveredBand !== "r" ? 0 : 1,
-      y: hoveredBand && hoveredBand !== "y" ? 0 : 1,
-      i: hoveredBand && hoveredBand !== "i" ? 0 : 1,
-      z: hoveredBand && hoveredBand !== "z" ? 0 : 1,
-      g: hoveredBand && hoveredBand !== "g" ? 0 : 1,
-    };
-  }, [hoveredBand]);
 
   const handleMouseEnter = (payload) => {
     setHoveredBand(payload.dataKey);
@@ -459,6 +445,51 @@ function ObservingConditionsApplet({
     // Otherwise use selected range as-is
     return [selectedMinMillis, selectedMaxMillis];
   }, [selectedMinMillis, selectedMaxMillis, xMin, xMax]);
+
+  // opacity for each band based on hovering state.
+  // EBA bar hover takes precedence: dims bands with no matching exposures
+  // within the currently visible x range. Otherwise falls back to legend
+  // hover (hide non-hovered bands).
+  const opacity = useMemo(() => {
+    if (hoveredExposureIds !== null) {
+      const visibleData = chartData.filter(
+        (d) => d.obs_start_dt >= xDomain[0] && d.obs_start_dt <= xDomain[1],
+      );
+      return Object.fromEntries(
+        ["u", "g", "r", "i", "z", "y"].map((band) => [
+          band,
+          visibleData.some(
+            (d) =>
+              d.band === band && hoveredExposureIds.has(String(d.exposure_id)),
+          )
+            ? 1
+            : 0.12,
+        ]),
+      );
+    }
+    return {
+      u: hoveredBand && hoveredBand !== "u" ? 0 : 1,
+      r: hoveredBand && hoveredBand !== "r" ? 0 : 1,
+      y: hoveredBand && hoveredBand !== "y" ? 0 : 1,
+      i: hoveredBand && hoveredBand !== "i" ? 0 : 1,
+      z: hoveredBand && hoveredBand !== "z" ? 0 : 1,
+      g: hoveredBand && hoveredBand !== "g" ? 0 : 1,
+    };
+  }, [hoveredBand, hoveredExposureIds, chartData, xDomain]);
+
+  // Returns the opacity for a single dot.
+  // When an EBA bar is hovered, matching exposures are full opacity and
+  // non-matching are dimmed. Otherwise falls back to band-level opacity
+  // (driven by legend hover).
+  const dotOpacity = useCallback(
+    (exposureId, bandOpacity) => {
+      if (hoveredExposureIds !== null) {
+        return hoveredExposureIds.has(String(exposureId)) ? 1 : 0.12;
+      }
+      return bandOpacity;
+    },
+    [hoveredExposureIds],
+  );
 
   // Click & Drag plot hooks
   const handleSelection = useCallback(
@@ -799,13 +830,13 @@ function ObservingConditionsApplet({
                         yAxisId="right"
                         type="monotone"
                         dataKey="zero_point_median"
-                        dot={({ key, ...restProps }) => (
+                        dot={({ key, payload, ...restProps }) => (
                           <ObservingConditionsAppletDot
                             key={key}
                             {...restProps}
                             band="u"
                             r={2}
-                            opacity={opacity.u}
+                            opacity={dotOpacity(payload.exposure_id, opacity.u)}
                           />
                         )}
                         strokeOpacity={opacity.u}
@@ -819,13 +850,13 @@ function ObservingConditionsApplet({
                         dataKey="zero_point_median"
                         stroke={BAND_COLORS.g}
                         strokeOpacity={opacity.g}
-                        dot={({ key, ...restProps }) => (
+                        dot={({ key, payload, ...restProps }) => (
                           <ObservingConditionsAppletDot
                             key={key}
                             {...restProps}
                             band="g"
                             r={2}
-                            opacity={opacity.g}
+                            opacity={dotOpacity(payload.exposure_id, opacity.g)}
                           />
                         )}
                         data={dataWithNightGaps(groupedChartData, "g")}
@@ -838,13 +869,13 @@ function ObservingConditionsApplet({
                         dataKey="zero_point_median"
                         stroke={BAND_COLORS.r}
                         strokeOpacity={opacity.r}
-                        dot={({ key, ...restProps }) => (
+                        dot={({ key, payload, ...restProps }) => (
                           <ObservingConditionsAppletDot
                             key={key}
                             {...restProps}
                             band="r"
                             r={2}
-                            opacity={opacity.r}
+                            opacity={dotOpacity(payload.exposure_id, opacity.r)}
                           />
                         )}
                         data={dataWithNightGaps(groupedChartData, "r")}
@@ -857,13 +888,13 @@ function ObservingConditionsApplet({
                         dataKey="zero_point_median"
                         stroke={BAND_COLORS.i}
                         strokeOpacity={opacity.i}
-                        dot={({ key, ...restProps }) => (
+                        dot={({ key, payload, ...restProps }) => (
                           <ObservingConditionsAppletDot
                             key={key}
                             {...restProps}
                             band="i"
                             r={2}
-                            opacity={opacity.i}
+                            opacity={dotOpacity(payload.exposure_id, opacity.i)}
                           />
                         )}
                         data={dataWithNightGaps(groupedChartData, "i")}
@@ -876,13 +907,13 @@ function ObservingConditionsApplet({
                         dataKey="zero_point_median"
                         stroke={BAND_COLORS.z}
                         strokeOpacity={opacity.z}
-                        dot={({ key, ...restProps }) => (
+                        dot={({ key, payload, ...restProps }) => (
                           <ObservingConditionsAppletDot
                             key={key}
                             {...restProps}
                             band="z"
                             r={2}
-                            opacity={opacity.z}
+                            opacity={dotOpacity(payload.exposure_id, opacity.z)}
                           />
                         )}
                         data={dataWithNightGaps(groupedChartData, "z")}
@@ -895,13 +926,13 @@ function ObservingConditionsApplet({
                         dataKey="zero_point_median"
                         stroke={BAND_COLORS.y}
                         strokeOpacity={opacity.y}
-                        dot={({ key, ...restProps }) => (
+                        dot={({ key, payload, ...restProps }) => (
                           <ObservingConditionsAppletDot
                             key={key}
                             {...restProps}
                             band="y"
                             r={2}
-                            opacity={opacity.y}
+                            opacity={dotOpacity(payload.exposure_id, opacity.y)}
                           />
                         )}
                         data={dataWithNightGaps(groupedChartData, "y")}
@@ -918,7 +949,10 @@ function ObservingConditionsApplet({
                             {...restProps}
                             color="#fff"
                             band="seeing"
-                            opacity={opacity[payload.band] ?? 1}
+                            opacity={dotOpacity(
+                              payload.exposure_id,
+                              opacity[payload.band] ?? 1,
+                            )}
                           />
                         )}
                         yAxisId="left"

--- a/src/components/ObservingConditionsApplet.jsx
+++ b/src/components/ObservingConditionsApplet.jsx
@@ -52,6 +52,11 @@ import {
 // Constants for gap detection
 const GAP_THRESHOLD = 5 * 60 * 1000;
 
+// Opacity applied to dimmed zero-point bands/dots (EBA hover or legend hover)
+const DIMMED_OPACITY_ZP = 0.02;
+// Opacity applied to dimmed seeing dots (EBA hover or legend hover)
+const DIMMED_OPACITY_SEEING = 0.06;
+
 const CustomTooltip = ({ active, payload, label, xDomain }) => {
   const dataKeyTitles = {
     psf_median: "PSF FWHM",
@@ -463,17 +468,17 @@ function ObservingConditionsApplet({
               d.band === band && hoveredExposureIds.has(String(d.exposure_id)),
           )
             ? 1
-            : 0.12,
+            : DIMMED_OPACITY_ZP,
         ]),
       );
     }
     return {
-      u: hoveredBand && hoveredBand !== "u" ? 0 : 1,
-      r: hoveredBand && hoveredBand !== "r" ? 0 : 1,
-      y: hoveredBand && hoveredBand !== "y" ? 0 : 1,
-      i: hoveredBand && hoveredBand !== "i" ? 0 : 1,
-      z: hoveredBand && hoveredBand !== "z" ? 0 : 1,
-      g: hoveredBand && hoveredBand !== "g" ? 0 : 1,
+      u: hoveredBand && hoveredBand !== "u" ? DIMMED_OPACITY_ZP : 1,
+      r: hoveredBand && hoveredBand !== "r" ? DIMMED_OPACITY_ZP : 1,
+      y: hoveredBand && hoveredBand !== "y" ? DIMMED_OPACITY_ZP : 1,
+      i: hoveredBand && hoveredBand !== "i" ? DIMMED_OPACITY_ZP : 1,
+      z: hoveredBand && hoveredBand !== "z" ? DIMMED_OPACITY_ZP : 1,
+      g: hoveredBand && hoveredBand !== "g" ? DIMMED_OPACITY_ZP : 1,
     };
   }, [hoveredBand, hoveredExposureIds, chartData, xDomain]);
 
@@ -484,7 +489,9 @@ function ObservingConditionsApplet({
   const dotOpacity = useCallback(
     (exposureId, bandOpacity) => {
       if (hoveredExposureIds !== null) {
-        return hoveredExposureIds.has(String(exposureId)) ? 1 : 0.12;
+        return hoveredExposureIds.has(String(exposureId))
+          ? 1
+          : DIMMED_OPACITY_ZP;
       }
       return bandOpacity;
     },
@@ -615,6 +622,19 @@ function ObservingConditionsApplet({
       if (i === 0) return filtered;
 
       return [{ obs_start_dt: null, zero_point_median: null }, ...filtered];
+    });
+  };
+
+  // Like dataWithNightGaps, but additionally nulls out zero_point_median for
+  // exposures not in hoveredExposureIds. Used to draw the full-opacity overlay
+  // line that connects only matching dots when an EBA bar is hovered.
+  const filterByBandAndHover = (data, band) => {
+    return dataWithNightGaps(data, band).map((d) => {
+      if (d.zero_point_median === null) return d;
+      if (!hoveredExposureIds.has(String(d.exposure_id))) {
+        return { ...d, zero_point_median: null };
+      }
+      return d;
     });
   };
 
@@ -825,119 +845,69 @@ function ObservingConditionsApplet({
                         isAnimationActive={false}
                       />
                       /* line plots for zero point median filtered by band */
-                      <Line
-                        name="zero_point_median_u"
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="zero_point_median"
-                        dot={({ key, payload, ...restProps }) => (
-                          <ObservingConditionsAppletDot
-                            key={key}
-                            {...restProps}
-                            band="u"
-                            r={2}
-                            opacity={dotOpacity(payload.exposure_id, opacity.u)}
+                      {/* Base lines — dimmed when EBA bar hovered, dots hidden
+                          in that case (overlay lines handle matching dots) */}
+                      {["u", "g", "r", "i", "z", "y"].map((band) => (
+                        <Line
+                          key={`zero_point_median_${band}`}
+                          name={`zero_point_median_${band}`}
+                          yAxisId="right"
+                          type="monotone"
+                          dataKey="zero_point_median"
+                          stroke={BAND_COLORS[band]}
+                          strokeOpacity={
+                            hoveredExposureIds !== null
+                              ? DIMMED_OPACITY_ZP
+                              : opacity[band]
+                          }
+                          dot={({ key, payload, ...restProps }) => (
+                            <ObservingConditionsAppletDot
+                              key={key}
+                              {...restProps}
+                              band={band}
+                              r={2}
+                              opacity={
+                                hoveredExposureIds !== null
+                                  ? DIMMED_OPACITY_ZP
+                                  : dotOpacity(
+                                      payload.exposure_id,
+                                      opacity[band],
+                                    )
+                              }
+                            />
+                          )}
+                          activeDot={
+                            hoveredExposureIds !== null ? false : undefined
+                          }
+                          data={dataWithNightGaps(groupedChartData, band)}
+                          isAnimationActive={false}
+                        />
+                      ))}
+                      {/* Overlay lines — full opacity, only matching dots and
+                          the segments connecting them, rendered on top of base */}
+                      {hoveredExposureIds !== null &&
+                        ["u", "g", "r", "i", "z", "y"].map((band) => (
+                          <Line
+                            key={`zero_point_median_${band}_overlay`}
+                            name={`zero_point_median_${band}_overlay`}
+                            yAxisId="right"
+                            type="monotone"
+                            dataKey="zero_point_median"
+                            stroke={BAND_COLORS[band]}
+                            strokeOpacity={1}
+                            dot={({ key, ...restProps }) => (
+                              <ObservingConditionsAppletDot
+                                key={key}
+                                {...restProps}
+                                band={band}
+                                r={2}
+                                opacity={1}
+                              />
+                            )}
+                            data={filterByBandAndHover(groupedChartData, band)}
+                            isAnimationActive={false}
                           />
-                        )}
-                        strokeOpacity={opacity.u}
-                        data={dataWithNightGaps(groupedChartData, "u")}
-                        isAnimationActive={false}
-                      />
-                      <Line
-                        name="zero_point_median_g"
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="zero_point_median"
-                        stroke={BAND_COLORS.g}
-                        strokeOpacity={opacity.g}
-                        dot={({ key, payload, ...restProps }) => (
-                          <ObservingConditionsAppletDot
-                            key={key}
-                            {...restProps}
-                            band="g"
-                            r={2}
-                            opacity={dotOpacity(payload.exposure_id, opacity.g)}
-                          />
-                        )}
-                        data={dataWithNightGaps(groupedChartData, "g")}
-                        isAnimationActive={false}
-                      />
-                      <Line
-                        name="zero_point_median_r"
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="zero_point_median"
-                        stroke={BAND_COLORS.r}
-                        strokeOpacity={opacity.r}
-                        dot={({ key, payload, ...restProps }) => (
-                          <ObservingConditionsAppletDot
-                            key={key}
-                            {...restProps}
-                            band="r"
-                            r={2}
-                            opacity={dotOpacity(payload.exposure_id, opacity.r)}
-                          />
-                        )}
-                        data={dataWithNightGaps(groupedChartData, "r")}
-                        isAnimationActive={false}
-                      />
-                      <Line
-                        name="zero_point_median_i"
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="zero_point_median"
-                        stroke={BAND_COLORS.i}
-                        strokeOpacity={opacity.i}
-                        dot={({ key, payload, ...restProps }) => (
-                          <ObservingConditionsAppletDot
-                            key={key}
-                            {...restProps}
-                            band="i"
-                            r={2}
-                            opacity={dotOpacity(payload.exposure_id, opacity.i)}
-                          />
-                        )}
-                        data={dataWithNightGaps(groupedChartData, "i")}
-                        isAnimationActive={false}
-                      />
-                      <Line
-                        name="zero_point_median_z"
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="zero_point_median"
-                        stroke={BAND_COLORS.z}
-                        strokeOpacity={opacity.z}
-                        dot={({ key, payload, ...restProps }) => (
-                          <ObservingConditionsAppletDot
-                            key={key}
-                            {...restProps}
-                            band="z"
-                            r={2}
-                            opacity={dotOpacity(payload.exposure_id, opacity.z)}
-                          />
-                        )}
-                        data={dataWithNightGaps(groupedChartData, "z")}
-                        isAnimationActive={false}
-                      />
-                      <Line
-                        name="zero_point_median_y"
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="zero_point_median"
-                        stroke={BAND_COLORS.y}
-                        strokeOpacity={opacity.y}
-                        dot={({ key, payload, ...restProps }) => (
-                          <ObservingConditionsAppletDot
-                            key={key}
-                            {...restProps}
-                            band="y"
-                            r={2}
-                            opacity={dotOpacity(payload.exposure_id, opacity.y)}
-                          />
-                        )}
-                        data={dataWithNightGaps(groupedChartData, "y")}
-                        isAnimationActive={false}
-                      />
+                        ))}
                       /* Scatter plot for PSF FWHM */
                       <Scatter
                         name="psf_median"
@@ -949,10 +919,17 @@ function ObservingConditionsApplet({
                             {...restProps}
                             color="#fff"
                             band="seeing"
-                            opacity={dotOpacity(
-                              payload.exposure_id,
-                              opacity[payload.band] ?? 1,
-                            )}
+                            opacity={
+                              hoveredExposureIds !== null
+                                ? hoveredExposureIds.has(
+                                    String(payload.exposure_id),
+                                  )
+                                  ? 1
+                                  : DIMMED_OPACITY_SEEING
+                                : hoveredBand && hoveredBand !== payload.band
+                                  ? DIMMED_OPACITY_SEEING
+                                  : 1
+                            }
                           />
                         )}
                         yAxisId="left"

--- a/src/components/ObservingConditionsApplet.jsx
+++ b/src/components/ObservingConditionsApplet.jsx
@@ -52,10 +52,12 @@ import {
 // Constants for gap detection
 const GAP_THRESHOLD = 5 * 60 * 1000;
 
-// Opacity applied to dimmed zero-point bands/dots (EBA hover or legend hover)
+// Opacity applied to dimmed zero-point bands/dots (exposure breakdown applet bar hover or legend hover)
 const DIMMED_OPACITY_ZP = 0.02;
-// Opacity applied to dimmed seeing dots (EBA hover or legend hover)
+// Opacity applied to dimmed seeing dots (exposure breakdown applet bar hover or legend hover)
 const DIMMED_OPACITY_SEEING = 0.06;
+
+const BANDS = ["u", "g", "r", "i", "z", "y"];
 
 const CustomTooltip = ({ active, payload, label, xDomain }) => {
   const dataKeyTitles = {
@@ -452,16 +454,16 @@ function ObservingConditionsApplet({
   }, [selectedMinMillis, selectedMaxMillis, xMin, xMax]);
 
   // opacity for each band based on hovering state.
-  // EBA bar hover takes precedence: dims bands with no matching exposures
-  // within the currently visible x range. Otherwise falls back to legend
-  // hover (hide non-hovered bands).
+  // hoveredExposureIds (exposure breakdown applet bar hover) takes precedence
+  // and dims bands with no matching exposures within the currently visible x range.
+  // Otherwise, falls back to legend hover (dim non-hovered bands).
   const opacity = useMemo(() => {
     if (hoveredExposureIds !== null) {
       const visibleData = chartData.filter(
         (d) => d.obs_start_dt >= xDomain[0] && d.obs_start_dt <= xDomain[1],
       );
       return Object.fromEntries(
-        ["u", "g", "r", "i", "z", "y"].map((band) => [
+        BANDS.map((band) => [
           band,
           visibleData.some(
             (d) =>
@@ -472,20 +474,18 @@ function ObservingConditionsApplet({
         ]),
       );
     }
-    return {
-      u: hoveredBand && hoveredBand !== "u" ? DIMMED_OPACITY_ZP : 1,
-      r: hoveredBand && hoveredBand !== "r" ? DIMMED_OPACITY_ZP : 1,
-      y: hoveredBand && hoveredBand !== "y" ? DIMMED_OPACITY_ZP : 1,
-      i: hoveredBand && hoveredBand !== "i" ? DIMMED_OPACITY_ZP : 1,
-      z: hoveredBand && hoveredBand !== "z" ? DIMMED_OPACITY_ZP : 1,
-      g: hoveredBand && hoveredBand !== "g" ? DIMMED_OPACITY_ZP : 1,
-    };
+    return Object.fromEntries(
+      BANDS.map((band) => [
+        band,
+        hoveredBand && hoveredBand !== band ? DIMMED_OPACITY_ZP : 1,
+      ]),
+    );
   }, [hoveredBand, hoveredExposureIds, chartData, xDomain]);
 
   // Returns the opacity for a single dot.
-  // When an EBA bar is hovered, matching exposures are full opacity and
-  // non-matching are dimmed. Otherwise falls back to band-level opacity
-  // (driven by legend hover).
+  // When an exposure breakdown applet bar is hovered, matching exposures
+  // are full opacity and non-matching are dimmed. Otherwise falls back
+  // to band-level opacity (driven by legend hover).
   const dotOpacity = useCallback(
     (exposureId, bandOpacity) => {
       if (hoveredExposureIds !== null) {
@@ -627,7 +627,8 @@ function ObservingConditionsApplet({
 
   // Like dataWithNightGaps, but additionally nulls out zero_point_median for
   // exposures not in hoveredExposureIds. Used to draw the full-opacity overlay
-  // line that connects only matching dots when an EBA bar is hovered.
+  // line that connects only matching dots when an exposure breakdown applet
+  // bar is hovered.
   const filterByBandAndHover = (data, band) => {
     return dataWithNightGaps(data, band).map((d) => {
       if (d.zero_point_median === null) return d;
@@ -845,9 +846,8 @@ function ObservingConditionsApplet({
                         isAnimationActive={false}
                       />
                       /* line plots for zero point median filtered by band */
-                      {/* Base lines — dimmed when EBA bar hovered, dots hidden
-                          in that case (overlay lines handle matching dots) */}
-                      {["u", "g", "r", "i", "z", "y"].map((band) => (
+                      {/* Base lines — dimmed when an exposure breakdown applet bar is hovered */}
+                      {BANDS.map((band) => (
                         <Line
                           key={`zero_point_median_${band}`}
                           name={`zero_point_median_${band}`}
@@ -866,6 +866,7 @@ function ObservingConditionsApplet({
                               {...restProps}
                               band={band}
                               r={2}
+                              // The dots are also dimmed if an exposure breakdown applet bar is hovered
                               opacity={
                                 hoveredExposureIds !== null
                                   ? DIMMED_OPACITY_ZP
@@ -883,10 +884,9 @@ function ObservingConditionsApplet({
                           isAnimationActive={false}
                         />
                       ))}
-                      {/* Overlay lines — full opacity, only matching dots and
-                          the segments connecting them, rendered on top of base */}
+                      {/* Overlay lines for hovered exposures — full opacity, only matching dots and the segments connecting them, rendered on top of base */}
                       {hoveredExposureIds !== null &&
-                        ["u", "g", "r", "i", "z", "y"].map((band) => (
+                        BANDS.map((band) => (
                           <Line
                             key={`zero_point_median_${band}_overlay`}
                             name={`zero_point_median_${band}_overlay`}

--- a/src/pages/Digest.jsx
+++ b/src/pages/Digest.jsx
@@ -77,11 +77,11 @@ export default function Digest() {
   const [blockLookup, setBlockLookup] = useState({});
 
   const [hoveredExposureIds, setHoveredExposureIds] = useState(null);
-  const handleEBABarHover = useCallback(
+  const onBarHover = useCallback(
     (ids) => setHoveredExposureIds(new Set(ids)),
     [],
   );
-  const handleEBABarLeave = useCallback(() => setHoveredExposureIds(null), []);
+  const onBarLeave = useCallback(() => setHoveredExposureIds(null), []);
 
   // Fetch all data except Zephyr data,
   // which needs exposure data.
@@ -463,8 +463,8 @@ export default function Digest() {
               blockLookup={blockLookup}
               exposuresLoading={exposuresLoading}
               flagsLoading={flagsLoading}
-              onBarHover={handleEBABarHover}
-              onBarLeave={handleEBABarLeave}
+              onBarHover={onBarHover}
+              onBarLeave={onBarLeave}
             />
           </div>
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">

--- a/src/pages/Digest.jsx
+++ b/src/pages/Digest.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { Toaster } from "@/components/ui/sonner";
 import { toast } from "sonner";
 import ExposureBreakdownApplet from "@/components/ExposureBreakdownApplet.jsx";
@@ -75,6 +75,13 @@ export default function Digest() {
   const [visitMapLoading, setVisitMapLoading] = useState(false);
 
   const [blockLookup, setBlockLookup] = useState({});
+
+  const [hoveredExposureIds, setHoveredExposureIds] = useState(null);
+  const handleEBABarHover = useCallback(
+    (ids) => setHoveredExposureIds(new Set(ids)),
+    [],
+  );
+  const handleEBABarLeave = useCallback(() => setHoveredExposureIds(null), []);
 
   // Fetch all data except Zephyr data,
   // which needs exposure data.
@@ -446,6 +453,7 @@ export default function Digest() {
               fullTimeRange={fullTimeRange}
               selectedTimeRange={selectedTimeRange}
               setSelectedTimeRange={setSelectedTimeRange}
+              hoveredExposureIds={hoveredExposureIds}
             />
             <ExposureBreakdownApplet
               exposureFields={exposureFields}
@@ -455,6 +463,8 @@ export default function Digest() {
               blockLookup={blockLookup}
               exposuresLoading={exposuresLoading}
               flagsLoading={flagsLoading}
+              onBarHover={handleEBABarHover}
+              onBarLeave={handleEBABarLeave}
             />
           </div>
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
Hovering a bar in the Exposure Breakdown applet now highlights the corresponding observations in the Observing Conditions applet.

Also update the hover opacity for the legend band-based hovering to match, and differentiate between dimmed opacities for ZP & seeing (as they are different colors and sizes, they need different opacities to appear to be 'dimmed' by the same amount according to human perception)