### PR TITLE
OSW-2119: Hide tips by default

### DIFF
--- a/doc/news/OSW-2119.misc.rst
+++ b/doc/news/OSW-2119.misc.rst
@@ -1,0 +1,1 @@
+Hide tips by default across ND pages.

--- a/src/pages/ContextFeed.jsx
+++ b/src/pages/ContextFeed.jsx
@@ -96,7 +96,7 @@ function ContextFeed() {
 
   // Visibility toggles
   const [timelineVisible, setTimelineVisible] = useState(true);
-  const [tipsVisible, setTipsVisible] = useState(true);
+  const [tipsVisible, setTipsVisible] = useState(false);
 
   // Default event type filters based on telescope
   const defaultEventTypes = filterDefaultEventsByTelescope(telescope);

--- a/src/pages/DataLog.jsx
+++ b/src/pages/DataLog.jsx
@@ -80,7 +80,7 @@ function DataLog() {
 
   // Visibility toggles
   const [timelineVisible, setTimelineVisible] = useState(true);
-  const [tipsVisible, setTipsVisible] = useState(true);
+  const [tipsVisible, setTipsVisible] = useState(false);
 
   // Time range state synced with URL
   const { selectedTimeRange, setSelectedTimeRange, fullTimeRange } =

--- a/src/pages/Plots.jsx
+++ b/src/pages/Plots.jsx
@@ -85,7 +85,7 @@ function Plots() {
 
   // Visibility toggles
   const [timelineVisible, setTimelineVisible] = useState(true);
-  const [tipsVisible, setTipsVisible] = useState(true);
+  const [tipsVisible, setTipsVisible] = useState(false);
 
   // Keep track of default and user-added plots
   const [visiblePlots, setVisiblePlots] = useState(


### PR DESCRIPTION
The original ticket was for just the Context Feed, but we should have consistency across our pages.
All pages now have tips hidden by default.