### PR TITLE
OSW 2285: Context Feed/Data-log cascading rerenders

### DIFF
--- a/doc/news/OSW-2285.perf.rst
+++ b/doc/news/OSW-2285.perf.rst
@@ -1,0 +1,1 @@
+Reduced unnecessary re-renders on the Data Log and Context Feed pages.

--- a/src/components/DataTable/useUrlSync.js
+++ b/src/components/DataTable/useUrlSync.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { getColumnUrlMappings } from "./tableUtils";
 
@@ -22,131 +22,82 @@ export function useUrlSync({ routePath, columns = [], defaultFilters = [] }) {
     [columns],
   );
 
-  // Extract only the filter-related params from searchParams as a stable string
-  const filterParamsJson = useMemo(() => {
-    const filterParams = {};
-    for (const key of urlParamKeys) {
-      if (searchParams[key] !== undefined) {
-        filterParams[key] = searchParams[key];
-      }
-    }
-    return JSON.stringify(filterParams);
-  }, [searchParams, urlParamKeys]);
-
-  // Parse a URL param value into an array
-  // Handles: arrays, comma-separated strings, and single values
-  const parseParamValue = (value) => {
-    if (Array.isArray(value)) {
-      return value;
-    }
-    if (typeof value === "string" && value.includes(",")) {
-      return value.split(",").map((v) => v.trim());
-    }
-    return [value];
-  };
-
-  // Build filters from URL params (falls back to defaultFilters if no URL params)
-  const buildFiltersFromUrl = useCallback(() => {
+  // Derive columnFilters directly from URL params (falls back to defaultFilters if none)
+  const columnFilters = useMemo(() => {
     const filters = [];
     for (const [urlParam, columnId] of Object.entries(urlParamToColumnId)) {
       const value = searchParams[urlParam];
       if (value !== undefined && value !== null && value !== "") {
-        filters.push({
-          id: columnId,
-          value: parseParamValue(value),
-        });
+        filters.push({ id: columnId, value: parseParamValue(value) });
       }
     }
-    // If no filters in URL, use defaults
     return filters.length > 0 ? filters : defaultFilters;
   }, [searchParams, urlParamToColumnId, defaultFilters]);
 
-  // Initialize state from URL (only on first render)
-  const [columnFilters, setColumnFiltersState] = useState(buildFiltersFromUrl);
-
-  // Track the last filterParamsJson we processed to avoid loops
-  const lastProcessedParams = useRef(filterParamsJson);
-
-  // Sync URL changes to state (for browser back/forward)
-  useEffect(() => {
-    // Only update if the filter params actually changed
-    if (lastProcessedParams.current === filterParamsJson) {
-      return;
-    }
-    lastProcessedParams.current = filterParamsJson;
-    const newFilters = buildFiltersFromUrl();
-    setColumnFiltersState(newFilters);
-  }, [filterParamsJson, buildFiltersFromUrl]);
-
-  // Custom setter that updates both state and URL
+  // Custom setter that updates the URL (columnFilters is derived from URL automatically)
   const setColumnFilters = useCallback(
     (filtersOrUpdater) => {
-      setColumnFiltersState((prevFilters) => {
-        const newFilters =
-          typeof filtersOrUpdater === "function"
-            ? filtersOrUpdater(prevFilters)
-            : filtersOrUpdater;
+      const newFilters =
+        typeof filtersOrUpdater === "function"
+          ? filtersOrUpdater(columnFilters)
+          : filtersOrUpdater;
 
-        // Build new URL params (preserve non-filter params)
-        const newParams = { ...searchParams };
+      // Build new URL params (preserve non-filter params)
+      const newParams = { ...searchParams };
 
-        // Remove old filter params
-        for (const urlParam of urlParamKeys) {
-          if (Object.hasOwn(newParams, urlParam)) {
-            delete newParams[urlParam];
-          }
+      // Remove old filter params
+      for (const urlParam of urlParamKeys) {
+        if (Object.hasOwn(newParams, urlParam)) {
+          delete newParams[urlParam];
         }
+      }
 
-        // Add current filters
-        for (const filter of newFilters) {
-          const urlParam = columnIdToUrlParam[filter.id];
-          if (urlParam && filter.value) {
-            newParams[urlParam] = Array.isArray(filter.value)
-              ? filter.value
-              : [filter.value];
-          }
+      // Add current filters
+      for (const filter of newFilters) {
+        const urlParam = columnIdToUrlParam[filter.id];
+        if (urlParam && filter.value) {
+          newParams[urlParam] = Array.isArray(filter.value)
+            ? filter.value
+            : [filter.value];
         }
+      }
 
-        // Update the ref so the effect doesn't re-process this change
-        const newFilterParams = {};
-        for (const key of urlParamKeys) {
-          if (newParams[key] !== undefined) {
-            newFilterParams[key] = newParams[key];
-          }
-        }
-        lastProcessedParams.current = JSON.stringify(newFilterParams);
-
-        navigate({ to: routePath, search: newParams, replace: true });
-
-        return newFilters;
-      });
+      navigate({ to: routePath, search: newParams, replace: true });
     },
-    [searchParams, navigate, routePath, columnIdToUrlParam, urlParamKeys],
+    [
+      columnFilters,
+      searchParams,
+      navigate,
+      routePath,
+      columnIdToUrlParam,
+      urlParamKeys,
+    ],
   );
 
-  // Reset filters: clears filter params from URL and sets state to defaultFilters
+  // Reset filters: clears filter params from URL; columnFilters falls back to defaultFilters
   const resetFilters = useCallback(() => {
-    // Build new URL params without any filter params
     const newParams = { ...searchParams };
     for (const urlParam of urlParamKeys) {
       if (Object.hasOwn(newParams, urlParam)) {
         delete newParams[urlParam];
       }
     }
-
-    // Update ref so the effect doesn't re-process
-    lastProcessedParams.current = JSON.stringify({});
-
-    // Clear filter params from URL
     navigate({ to: routePath, search: newParams, replace: true });
-
-    // Set state to defaults (not written to URL)
-    setColumnFiltersState(defaultFilters);
-  }, [searchParams, navigate, routePath, urlParamKeys, defaultFilters]);
+  }, [searchParams, navigate, routePath, urlParamKeys]);
 
   return {
     columnFilters,
     setColumnFilters,
     resetFilters,
   };
+}
+
+// Parse a URL param value into an array.
+// Handles: arrays, comma-separated strings, and single values.
+function parseParamValue(value) {
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string" && value.includes(",")) {
+    return value.split(",").map((v) => v.trim());
+  }
+  return [value];
 }

--- a/src/hooks/useTimeRangeFromURL.js
+++ b/src/hooks/useTimeRangeFromURL.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import {
   getDayobsStartUTC,
@@ -35,10 +35,24 @@ import {
  * setSelectedTimeRange([newStart, newEnd]);
  */
 export function useTimeRangeFromURL(routePath) {
-  // Get all search params from the URL
-  const { startDayobs, endDayobs, startTime, endTime } = useSearch({
+  // Get only the search params we need using select to prevent unnecessary re-renders
+  const { startDayobs, endDayobs } = useSearch({
     from: routePath,
+    select: (search) => ({
+      startDayobs: search.startDayobs,
+      endDayobs: search.endDayobs,
+    }),
   });
+
+  const { startTime, endTime } = useSearch({
+    from: routePath,
+    select: (search) => ({
+      startTime: search.startTime,
+      endTime: search.endTime,
+    }),
+  });
+
+  const navigate = useNavigate({ from: routePath });
 
   // Calculate the full valid time range based on dayobs parameters
   const fullTimeRange = useMemo(
@@ -49,60 +63,44 @@ export function useTimeRangeFromURL(routePath) {
     [startDayobs, endDayobs],
   );
 
-  // Initialize state from URL params, validating against fullTimeRange
-  const [selectedTimeRange, setSelectedTimeRangeInternal] = useState(() => {
+  // Derive selectedTimeRange directly from URL params
+  const selectedTimeRange = useMemo(() => {
     const startMillis = Number(startTime);
     const endMillis = Number(endTime);
     return getValidTimeRange(startMillis, endMillis, fullTimeRange);
-  });
-
-  const navigate = useNavigate({ from: routePath });
-  const searchParams = useSearch({ from: routePath });
-
-  // Sync URL time params → state when URL changes externally
-  useEffect(() => {
-    const startMillis = Number(startTime);
-    const endMillis = Number(endTime);
-    const newRange = getValidTimeRange(startMillis, endMillis, fullTimeRange);
-
-    if (
-      newRange[0].toMillis() !== selectedTimeRange[0].toMillis() ||
-      newRange[1].toMillis() !== selectedTimeRange[1].toMillis()
-    ) {
-      setSelectedTimeRangeInternal(newRange);
-    }
-  }, [startTime, endTime, fullTimeRange, selectedTimeRange]);
+  }, [startTime, endTime, fullTimeRange]);
 
   // Wrapped setter that updates both state and URL
-  const setSelectedTimeRange = (newRange) => {
-    if (
-      !newRange[0] ||
-      !newRange[1] ||
-      Number.isNaN(newRange[0].toMillis()) ||
-      Number.isNaN(newRange[1].toMillis())
-    ) {
-      console.warn(
-        "setSelectedTimeRange called with invalid values: ",
-        newRange,
-      );
-      return;
-    }
+  const setSelectedTimeRange = useCallback(
+    (newRange) => {
+      if (
+        !newRange[0] ||
+        !newRange[1] ||
+        Number.isNaN(newRange[0].toMillis()) ||
+        Number.isNaN(newRange[1].toMillis())
+      ) {
+        console.warn(
+          "setSelectedTimeRange called with invalid values: ",
+          newRange,
+        );
+        return;
+      }
 
-    setSelectedTimeRangeInternal(newRange);
+      const newStart = newRange[0].toMillis();
+      const newEnd = newRange[1].toMillis();
 
-    const newStart = newRange[0].toMillis();
-    const newEnd = newRange[1].toMillis();
-
-    navigate({
-      to: routePath,
-      search: {
-        ...searchParams,
-        startTime: newStart,
-        endTime: newEnd,
-      },
-      replace: true,
-    });
-  };
+      navigate({
+        to: routePath,
+        search: (prev) => ({
+          ...prev,
+          startTime: newStart,
+          endTime: newEnd,
+        }),
+        replace: true,
+      });
+    },
+    [navigate, routePath],
+  );
 
   return { selectedTimeRange, setSelectedTimeRange, fullTimeRange };
 }


### PR DESCRIPTION
The URL sync hooks had an issue where they would cause multiple cascading renders (one would update state and navigate, which caused the other one to rerun even though its state hadn't actually changed, which would also cause the first to rerun and then settle). This was because the `setState` and `navigate` calls were not batching as expected. By removing the `useState` and just deriving state directly from the URL, as well as being more selective about which bits of URL state are watched we bypass this and prevent multiple renders occurring, leading to a dramatic increase in performance.

<img width="848" height="235" alt="image" src="https://github.com/user-attachments/assets/b4ad7932-c332-4fe1-9d52-b9bb58eb19cf" />
