### PR TITLE
OSW-2415: Add nginx proxy cache keyed on request URL

### DIFF
--- a/doc/news/OSW-2415.perf.rst
+++ b/doc/news/OSW-2415.perf.rst
@@ -1,0 +1,2 @@
+Configured nginx proxy cache to cache API responses using
+``Cache-Control`` headers set by the backend.

--- a/doc/news/OSW-2415.perf.rst
+++ b/doc/news/OSW-2415.perf.rst
@@ -1,2 +1,1 @@
-Configured nginx proxy cache to cache API responses using
-``Cache-Control`` headers set by the backend.
+Configured nginx proxy cache to cache API responses using ``Cache-Control`` headers set by the backend.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,6 +12,12 @@ services:
     volumes:
       - ${FRONTEND_PATH}:/usr/src/app
       - /usr/src/app/node_modules
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:5173"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 30s
 
   backend:
     container_name: nightlydigest-backend
@@ -40,5 +46,8 @@ services:
     image: nginx:latest
     ports:
       - "80:80"
+    depends_on:
+      frontend:
+        condition: service_healthy
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,6 +1,20 @@
+proxy_cache_path /var/cache/nginx/nightlydigest
+                 levels=1:2
+                 keys_zone=nightlydigest_cache:10m
+                 max_size=1g
+                 inactive=1d
+                 use_temp_path=off;
+
+log_format cache_log '$remote_addr - $remote_user [$time_local] '
+                     '"$request" $status $body_bytes_sent '
+                     '"$http_referer" "$http_user_agent" '
+                     'cache=$upstream_cache_status';
+
 server {
   listen 80;
   server_name localhost;
+
+  access_log /var/log/nginx/access.log cache_log;
 
   location /nightlydigest {
     proxy_pass http://frontend:5173;
@@ -12,5 +26,14 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
+
+    proxy_pass_header Cache-Control;
+
+    proxy_cache nightlydigest_cache;
+    proxy_cache_key "$scheme$request_method$host$request_uri";
+    proxy_cache_use_stale error timeout updating;
+    proxy_cache_lock on;
+
+    add_header X-Cache-Status $upstream_cache_status;
   }
 }


### PR DESCRIPTION
Configures nginx to act as a cache, respecting the backends Cache-Control header. Depends on https://github.com/lsst-ts/ts_logging_and_reporting/pull/134 to do anything