### PR TITLE
OSW-2773: Implement automatic CI pipeline for image building in merges to develop.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,37 +1,24 @@
-properties(
-    [
-    buildDiscarder(
-        logRotator(
-            artifactDaysToKeepStr: '',
-            artifactNumToKeepStr: '',
-            daysToKeepStr: '14',
-            numToKeepStr: '10',
-        )
-    ),
-    // Make new builds terminate existing builds
-    disableConcurrentBuilds(
-        abortPrevious: true,
-    )
-    ]
-)
-
 pipeline {
-  agent{
-    docker {
-      alwaysPull true
-      image 'lsstts/develop-env:develop'
-      args "--entrypoint=''"
-    }
+  options {
+    disableConcurrentBuilds()
   }
+
+  agent any
+
   environment {
+    dockerImageName = "rubincr.lsst.org/nightlydigest-frontend:"
     dockerImage = ""
-    // LTD credentials
-    user_ci = credentials('lsst-io')
-    LTD_USERNAME="${user_ci_USR}"
-    LTD_PASSWORD="${user_ci_PSW}"
   }
+
   stages {
     stage("Run pre-commit hooks and tests") {
+      agent{
+        docker {
+          alwaysPull true
+          image 'lsstts/develop-env:develop'
+          args "--entrypoint=''"
+        }
+      }
       steps {
         script {
           sh """
@@ -47,6 +34,13 @@ pipeline {
       }
     }
     stage("Run e2e tests") {
+      agent{
+        docker {
+          alwaysPull true
+          image 'lsstts/develop-env:develop'
+          args "--entrypoint=''"
+        }
+      }
       steps {
         script {
           sh """
@@ -54,6 +48,37 @@ pipeline {
             npx playwright install chromium
             npm run test:e2e -- --reporter=list
           """
+        }
+      }
+    }
+
+    stage("Build Docker image") {
+      when {
+        anyOf {
+          branch "develop"
+        }
+      }
+      steps {
+        script {
+          image_tag = "develop"
+          dockerImageName = dockerImageName + image_tag
+          echo "dockerImageName: ${dockerImageName}"
+          dockerImage = docker.build(dockerImageName, "-f docker/Dockerfile-deploy .")
+        }
+      }
+    }
+    
+    stage("Push Docker image") {
+      when {
+        anyOf {
+          branch "develop"
+        }
+      }
+      steps {
+        script {
+          docker.withRegistry("https://rubincr.lsst.org/", "nexus3-lsst_jenkins") {
+            dockerImage.push()
+          }
         }
       }
     }

--- a/doc/news/OSW-2773.misc.rst
+++ b/doc/news/OSW-2773.misc.rst
@@ -1,0 +1,1 @@
+Implement automatic CI pipeline for image building in merges to develop.

--- a/docker/Dockerfile-deploy
+++ b/docker/Dockerfile-deploy
@@ -1,3 +1,16 @@
+FROM lsstts/develop-env:develop AS version_bumper
+
+WORKDIR /home/saluser/develop
+COPY scripts/make_release.py scripts/make_release.py
+COPY package.json package.json
+
+USER root
+RUN chown saluser:saluser /home/saluser/develop/package.json /home/saluser/develop/scripts/make_release.py
+USER saluser
+
+RUN source /home/saluser/.setup_dev.sh && \
+    python scripts/make_release.py --version develop --no-version-check --no-release-notes --no-git
+
 FROM rubincr.lsst.org/develop-env-javascript:ec-develop
 
 LABEL maintainer Sebastian Aranda <sebastian.aranda@noirlab.edu>
@@ -8,6 +21,9 @@ COPY . .
 USER root
 RUN chown -R saluser:saluser /usr/src/app
 USER saluser
+
+COPY --from=version_bumper /home/saluser/develop/package.json package.json
+COPY --from=version_bumper /home/saluser/develop/package-lock.json package-lock.json
 
 RUN npm install
 RUN npx vite build

--- a/docker/Dockerfile-deploy
+++ b/docker/Dockerfile-deploy
@@ -1,0 +1,15 @@
+FROM rubincr.lsst.org/develop-env-javascript:ec-develop
+
+LABEL maintainer Sebastian Aranda <sebastian.aranda@noirlab.edu>
+
+WORKDIR /usr/src/app
+COPY . .
+
+USER root
+RUN chown -R saluser:saluser /usr/src/app
+USER saluser
+
+RUN npm install
+RUN npx vite build
+
+VOLUME /usr/src/app/dist

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -23,7 +23,7 @@ SEMVER_REGEX = (
 )
 
 
-def run_towncrier_build(version: str):
+def run_towncrier_build(version: str, no_git: bool = False):
     """Run the towncrier build command to generate release notes.
 
     Parameters
@@ -36,11 +36,12 @@ def run_towncrier_build(version: str):
     subprocess.run(["towncrier", "build", "--yes", f"--version=v{version}"], check=True)
 
     # Stage and commit the generated changelog
-    subprocess.run(["git", "add", VERSION_HISTORY_PATH], check=True)
-    subprocess.run(["git", "commit", "-m", "Update the version history."], check=True)
+    if not no_git:
+        subprocess.run(["git", "add", VERSION_HISTORY_PATH], check=True)
+        subprocess.run(["git", "commit", "-m", "Update the version history."], check=True)
 
 
-def bump_package_json_metadata(version: str):
+def bump_package_json_metadata(version: str, no_git: bool = False):
     """Update `version` and `lastUpdated` fields
     in the package.json file.
 
@@ -68,8 +69,9 @@ def bump_package_json_metadata(version: str):
     subprocess.run(['npm', 'install', '--package-lock-only'])
 
     # Stage and commit the changes
-    subprocess.run(["git", "add", PACKAGE_JSON_PATH, PACKAGE_LOCK_PATH], check=True)
-    subprocess.run(["git", "commit", "-m", f"Bump package.json metadata for v{version}."], check=True)
+    if not no_git:
+        subprocess.run(["git", "add", PACKAGE_JSON_PATH, PACKAGE_LOCK_PATH], check=True)
+        subprocess.run(["git", "commit", "-m", f"Bump package.json metadata for v{version}."], check=True)
 
 
 def git_tag(version: str):
@@ -116,15 +118,41 @@ def main():
         type=str,
         help="The releasing version (just the number, without the v prefix)", required=True
     )
+    parser.add_argument(
+        "--no-version-check",
+        action="store_true",
+        help="Skip checking the version format (useful for non-semver versions)."
+    )
+    parser.add_argument(
+        "--no-release-notes",
+        action="store_true",
+        help="Skip generating release notes with towncrier."
+    )
+    parser.add_argument(
+        "--no-package-json",
+        action="store_true",
+        help="Skip updating package.json metadata."
+    )
+    parser.add_argument(
+        "--no-git",
+        action="store_true",
+        help="Skip committing changes to git (useful for testing)."
+    )
+
 
     args = parser.parse_args()
 
-    if not check_version_format(args.version):
+    if not args.no_version_check and not check_version_format(args.version):
         raise ValueError(f"Version '{args.version}' is not in valid semantic versioning format.")
 
-    run_towncrier_build(args.version)
-    bump_package_json_metadata(args.version)
-    git_tag(args.version)
+    if not args.no_release_notes:
+        run_towncrier_build(args.version, no_git=args.no_git)
+
+    if not args.no_package_json:
+        bump_package_json_metadata(args.version, no_git=args.no_git)
+
+    if not args.no_git:
+        git_tag(args.version)
 
 
 if __name__ == "__main__":

--- a/src/components/AppSidebar.jsx
+++ b/src/components/AppSidebar.jsx
@@ -15,7 +15,7 @@ import RubinIcon from "../assets/RubinIcon.svg";
 import packageJson from "../../package.json";
 
 export function AppSidebar({ ...props }) {
-  const [backendVersion, setBackendVersion] = useState("main");
+  const [backendVersion, setBackendVersion] = useState("develop");
   useEffect(() => {
     const abortController = new AbortController();
     fetchBackendVersion(abortController.signal).then((backendVersionString) => {
@@ -27,16 +27,19 @@ export function AppSidebar({ ...props }) {
     };
   }, []);
 
+  const frontendVersionIsDevelop = packageJson.version === "develop";
+  const backendVersionIsDevelop = backendVersion === "develop";
+
   const frontendReleaseNotesHref =
     "https://github.com/lsst-ts/ts_logging_frontend" +
     `/blob/${
-      packageJson.version !== "develop" ? `v${packageJson.version}` : "develop"
+      !frontendVersionIsDevelop ? `v${packageJson.version}` : "develop"
     }/doc/version_history.rst`;
 
   const backendReleaseNotesHref =
     "https://github.com/lsst-ts/ts_logging_and_reporting" +
     `/blob/${
-      backendVersion !== "main" ? `v${backendVersion}` : "main"
+      !backendVersionIsDevelop ? `v${backendVersion}` : "develop"
     }/doc/version_history.rst`;
 
   return (
@@ -78,7 +81,10 @@ export function AppSidebar({ ...props }) {
           <p>
             Nightly Digest{" "}
             <strong>
-              v{packageJson.version} ({packageJson.lastUpdated})
+              {!frontendVersionIsDevelop
+                ? `v${packageJson.version}`
+                : "develop"}{" "}
+              ({packageJson.lastUpdated})
             </strong>
           </p>
           <p>

--- a/src/components/AppSidebar.jsx
+++ b/src/components/AppSidebar.jsx
@@ -29,7 +29,9 @@ export function AppSidebar({ ...props }) {
 
   const frontendReleaseNotesHref =
     "https://github.com/lsst-ts/ts_logging_frontend" +
-    `/blob/v${packageJson.version}/doc/version_history.rst`;
+    `/blob/${
+      packageJson.version !== "develop" ? `v${packageJson.version}` : "develop"
+    }/doc/version_history.rst`;
 
   const backendReleaseNotesHref =
     "https://github.com/lsst-ts/ts_logging_and_reporting" +

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -514,10 +514,10 @@ const calculateSumExpTimeBetweenTwilights = (exposureFields, almanacInfo) => {
  * - "1.2.3a1" -> "1.2.3-alpha.1"
  * - "1.2.3rc1" -> "1.2.3-rc.1"
  * @returns The git tag corresponding to the version string
- * or "main" if the version string is unrecognized
+ * or "develop" if the version string is unrecognized
  */
 function parseBackendVersion(versionString) {
-  const defaultVersion = "main";
+  const defaultVersion = "develop";
   const match = versionString.match(/^(\d+\.\d+\.\d+)([a-z]\d+|rc\d+)?$/);
   if (!match) {
     console.warn(`Unrecognized version string: ${versionString}`);

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -751,16 +751,16 @@ describe("utils", () => {
     });
 
     it("returns 'main' for invalid version strings", () => {
-      expect(parseBackendVersion("invalid-version")).toBe("main");
-      expect(parseBackendVersion("v1.2")).toBe("main");
-      expect(parseBackendVersion("")).toBe("main");
-      expect(parseBackendVersion("1.2.3-unknown")).toBe("main");
+      expect(parseBackendVersion("invalid-version")).toBe("develop");
+      expect(parseBackendVersion("v1.2")).toBe("develop");
+      expect(parseBackendVersion("")).toBe("develop");
+      expect(parseBackendVersion("1.2.3-unknown")).toBe("develop");
       expect(parseBackendVersion("1.2.3.dev1+g6c0764173.d20251021")).toBe(
-        "main",
+        "develop",
       );
-      expect(parseBackendVersion("1.2.3-alpha.1")).toBe("main");
-      expect(parseBackendVersion("1.2.3a-1")).toBe("main");
-      expect(parseBackendVersion("1.2.3b1")).toBe("main");
+      expect(parseBackendVersion("1.2.3-alpha.1")).toBe("develop");
+      expect(parseBackendVersion("1.2.3a-1")).toBe("develop");
+      expect(parseBackendVersion("1.2.3b1")).toBe("develop");
     });
   });
 


### PR DESCRIPTION
This PR refactors the `Jenkinsfile` to have custom steps for image building when merging PRs to `develop`. A new `Dockerfile-deploy` file was added with the specifications for building images for our deployments.

Additionally adjustments were required in the section where we display packages version. As automatic builds won't create a git tag, this affects the current way we are showing versions. I would like to keep git tags only for manual processes (prod release or alpha manual release for dev), so we keep control of the set of changes we are packaging (instead of being creating tags for every single merge to develop).

Also the `make_release.py` script has been extended to support configuring which steps to run. Used for the automatic image build process and package.json version bumps.

See https://github.com/lsst-ts/ts_logging_and_reporting/pull/140.